### PR TITLE
Make data augmentation optional

### DIFF
--- a/autoreject/viz.py
+++ b/autoreject/viz.py
@@ -1231,7 +1231,7 @@ def _plot_histogram(params):
     params['histogram'].subplots_adjust(hspace=0.6)
     try:
         params['histogram'].show(warn=False)
-    except:
+    except Exception:
         pass
     if params['fig_proj'] is not None:
         params['fig_proj'].canvas.draw()

--- a/examples/plot_channel_thresholds.py
+++ b/examples/plot_channel_thresholds.py
@@ -51,7 +51,8 @@ import numpy as np  # noqa
 from autoreject import compute_thresholds  # noqa
 
 threshes = compute_thresholds(epochs, picks=picks, method='random_search',
-                              random_state=42, verbose='progressbar')
+                              random_state=42, augment=False,
+                              verbose='progressbar')
 
 ###############################################################################
 # Finally, let us plot a histogram of the channel-level thresholds to verify


### PR DESCRIPTION
@jbschiratti  reported to me that sometimes you just want to know the channel-level thresholds even if you don't have the channel locations: for example in the case of intracranial EEG data. Here is a small PR to add a boolean parameter `augment` to make data augmentation optional