### PR TITLE
Fix bug in selection of channels to interpolate

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -507,6 +507,8 @@ class LocalAutoReject(BaseAutoReject):
                     peaks[non_picks] = -np.inf
                     # find channels which are bad by rejection threshold
                     interp_chs_mask = drop_log[epoch_idx] == 1
+                    # ignore good channels
+                    peaks[~interp_chs_mask] = -np.inf
                     # find the ordering of channels amongst the bad channels
                     sorted_ch_idx_picks = np.argsort(peaks)[::-1]
                     # then select only the worst n_interpolate channels


### PR DESCRIPTION
Ignore good channels when there are more bad channels than n_interpolate by putting their values to minus infinite, like in the paper.

If this is not done explicitly, values of good channels can be lower because thresholds are different for each channel. This may lead to interpolate a lower number of channels than expected. So, they must be excluded, like in the reference paper.