### PR TITLE
fixed number of epochs rejected

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -530,7 +530,7 @@ class LocalAutoReject(BaseAutoReject):
         n_consensus = self.consensus_perc[ch_type] * n_channels
         if np.max(bad_sensor_counts) >= n_consensus:
             n_epochs_drop = np.sum(bad_sensor_counts >=
-                                   n_consensus) + 1
+                                   n_consensus)
             bad_epochs_idx = sorted_epoch_idx[:n_epochs_drop]
         else:
             n_epochs_drop = 0


### PR DESCRIPTION
See issue #87.

Now the number of epochs rejected is directly corresponding to the number of epochs in which #bad_channels > consensus. Before 1 more epoch was rejected.