### PR TITLE
[BUG] crack down interpolation crime

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -496,6 +496,7 @@ class LocalAutoReject(BaseAutoReject):
         for epoch_idx in range(len(epochs)):
             n_bads = drop_log[epoch_idx, self.picks].sum()
             if n_bads == 0:
+                interp_channels.append([])
                 continue
             else:
                 if n_bads <= n_interpolate:
@@ -546,7 +547,7 @@ class LocalAutoReject(BaseAutoReject):
 
         interp_channels, fix_log = self._get_epochs_interpolation(
             epochs, drop_log=drop_log, ch_type=ch_type)
-
+        assert len(interp_channels) == len(drop_log) == len(epochs)
         (bad_epochs_idx, sorted_epoch_idx,
          n_epochs_drop) = self._get_bad_epochs(
              bad_sensor_counts, ch_type=ch_type)

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -187,7 +187,7 @@ def test_autoreject():
     assert_true(isinstance(ar.threshes_, dict))
     assert_true(len(ar.picks) == len(picks))
     assert_true(len(ar.threshes_.keys()) == len(ar.picks))
-    pick_eog = mne.pick_types(epochs.info, meg=False, eeg=False, eog=True)
+    pick_eog = mne.pick_types(epochs.info, meg=False, eeg=False, eog=True)[0]
     assert_true(epochs.ch_names[pick_eog] not in ar.threshes_.keys())
     assert_raises(
         IndexError, ar.transform,


### PR DESCRIPTION
Immediately end the interpolation crimes committed on master ...
More precisely, this PR ensures that the final list of to be interpolated channels matches the fix_log and the epochs in length. As of now, it could happen that arbitrary epochs get interpolated.

cc @agramfort @jasmainak 
