### PR TITLE
WIP: Fix transform with bad channels.

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -664,7 +664,7 @@ def _interpolate_bad_epochs(
             desc='Repairing epochs',
             position=pos, leave=True, verbose=verbose):
         epoch = epochs[epoch_idx]
-        epoch.info['bads'] = interp_chs
+        epoch.info['bads'] += interp_chs
         interpolate_bads(epoch, picks=picks, reset_bads=True)
         epochs._data[epoch_idx] = epoch._data
 
@@ -742,36 +742,6 @@ def _run_local_reject_cv(epochs, thresh_func, picks_, n_interpolate, cv,
                 loss[idx, jdx, fold] = -local_reject.score(X[test])
 
     return local_reject, loss
-            (_, _, interp_channels, _,
-             bad_epochs_idx, good_epochs_idx) = self._annotate_epochs(
-                 threshes=self.threshes_, epochs=epochs)
-            if len(good_epochs_idx) == 0:
-                raise ValueError('All epochs are bad. Sorry.')
-
-            self._interpolate_bad_epochs(
-                epochs_out, interp_channels=interp_channels,
-                verbose=self.verbose)
-        if np.any(bad_epochs_idx):
-            epochs_out.drop(bad_epochs_idx, reason='AUTOREJECT')
-        else:
-            warnings.warn(
-                "No bad epochs were found for your data. Returning "
-                "a copy of the data you wanted to clean. Interpolation "
-                "may have been done.")
-        return epochs_out
-
-    def _interpolate_bad_epochs(
-            self, epochs, interp_channels, verbose='progressbar'):
-        """Actually do the interpolation."""
-        pos = 4 if hasattr(self, '_leave') else 2
-        for epoch_idx, interp_chs in _pbar(
-                list(enumerate(interp_channels)),
-                desc='Repairing epochs',
-                position=pos, leave=True, verbose=verbose):
-            epoch = epochs[epoch_idx]
-            epoch.info['bads'] += interp_chs
-            interpolate_bads(epoch, picks=self.picks, reset_bads=True)
-            epochs._data[epoch_idx] = epoch._data
 
 
 class LocalAutoRejectCV(object):

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -664,7 +664,7 @@ def _interpolate_bad_epochs(
             desc='Repairing epochs',
             position=pos, leave=True, verbose=verbose):
         epoch = epochs[epoch_idx]
-        epoch.info['bads'] += interp_chs
+        epoch.info['bads'] = interp_chs
         interpolate_bads(epoch, picks=picks, reset_bads=True)
         epochs._data[epoch_idx] = epoch._data
 

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -742,6 +742,36 @@ def _run_local_reject_cv(epochs, thresh_func, picks_, n_interpolate, cv,
                 loss[idx, jdx, fold] = -local_reject.score(X[test])
 
     return local_reject, loss
+            (_, _, interp_channels, _,
+             bad_epochs_idx, good_epochs_idx) = self._annotate_epochs(
+                 threshes=self.threshes_, epochs=epochs)
+            if len(good_epochs_idx) == 0:
+                raise ValueError('All epochs are bad. Sorry.')
+
+            self._interpolate_bad_epochs(
+                epochs_out, interp_channels=interp_channels,
+                verbose=self.verbose)
+        if np.any(bad_epochs_idx):
+            epochs_out.drop(bad_epochs_idx, reason='AUTOREJECT')
+        else:
+            warnings.warn(
+                "No bad epochs were found for your data. Returning "
+                "a copy of the data you wanted to clean. Interpolation "
+                "may have been done.")
+        return epochs_out
+
+    def _interpolate_bad_epochs(
+            self, epochs, interp_channels, verbose='progressbar'):
+        """Actually do the interpolation."""
+        pos = 4 if hasattr(self, '_leave') else 2
+        for epoch_idx, interp_chs in _pbar(
+                list(enumerate(interp_channels)),
+                desc='Repairing epochs',
+                position=pos, leave=True, verbose=verbose):
+            epoch = epochs[epoch_idx]
+            epoch.info['bads'] += interp_chs
+            interpolate_bads(epoch, picks=self.picks, reset_bads=True)
+            epochs._data[epoch_idx] = epoch._data
 
 
 class LocalAutoRejectCV(object):

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -90,13 +90,13 @@ def test_autoreject():
     pick_ch_names = [epochs.ch_names[pp] for pp in pre_picks]
     bad_ch_names = [epochs.ch_names[ix] for ix in range(len(epochs.ch_names))
 		    if ix not in pre_picks]
-    epochs_wbads = epochs.copy()
-    epochs_wbads.info['bads'] = bad_ch_names
+    epochs_with_bads = epochs.copy()
+    epochs_with_bads.info['bads'] = bad_ch_names
     epochs.pick_channels(pick_ch_names)
 
     epochs_fit = epochs[:12]  # make sure to use different size of epochs
     epochs_new = epochs[12:]
-    epochs_wbads_fit = epochs_wbads[:10]
+    epochs_with_bads_fit = epochs_with_bads[:12]
 
     X = epochs_fit.get_data()
     n_epochs, n_channels, n_times = X.shape
@@ -204,16 +204,16 @@ def test_autoreject():
 
     # test that transform ignores bad channels
     picks = mne.pick_types(
-        epochs_wbads.info, meg='mag', eeg=True, stim=False, eog=False,
+        epochs_with_bads.info, meg='mag', eeg=True, stim=False, eog=False,
         include=[], exclude=[])
     ch_types = ['mag', 'eeg']
     ar = LocalAutoRejectCV(cv=3, picks=picks, thresh_func=thresh_func,
-                           n_interpolates=[1, 2],
-                           consensus_percs=[0.5, 1])
-    ar.fit(epochs_wbads_fit)
-    epochs_wbads_clean = ar.transform(epochs_wbads_fit)
-    epochs_wbads_clean.pick_channels(pick_channel_names)
-    assert_array_equal(epochs_clean.get_data(), epochs_wbads_clean.get_data())
+                           n_interpolate=[1, 2],
+                           consensus=[0.5, 1])
+    ar.fit(epochs_with_bads_fit)
+    epochs_with_bads_clean = ar.transform(epochs_with_bads_fit)
+    epochs_with_bads_clean.pick_channels(pick_channel_names)
+    assert_array_equal(epochs_clean.get_data(), epochs_with_bads_clean.get_data())
 
     assert_equal(epochs_clean.ch_names, epochs_fit.ch_names)
 

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -89,7 +89,7 @@ def test_autoreject():
         mne.pick_types(epochs.info, meg=False, eeg=False, eog=True)]
     pick_ch_names = [epochs.ch_names[pp] for pp in pre_picks]
     bad_ch_names = [epochs.ch_names[ix] for ix in range(len(epochs.ch_names))
-		    if ix not in pre_picks]
+                    if ix not in pre_picks]
     epochs_with_bads = epochs.copy()
     epochs_with_bads.info['bads'] = bad_ch_names
     epochs.pick_channels(pick_ch_names)
@@ -207,15 +207,17 @@ def test_autoreject():
         epochs_with_bads.info, meg='mag', eeg=True, stim=False, eog=False,
         include=[], exclude='bads')
     ch_types = ['mag', 'eeg']
-    ar = LocalAutoRejectCV(cv=3, picks=picks_without_bads, 
+    ar = LocalAutoRejectCV(cv=3, picks=picks_without_bads,
                            thresh_func=thresh_func,
                            n_interpolate=[1, 2],
                            consensus=[0.5, 1])
     ar.fit(epochs_with_bads_fit)
     epochs_with_bads_clean = ar.transform(epochs_with_bads_fit)
 
-    epochs_with_bads_clean.pick_types(meg=True, eeg=True, eog=True, exclude='bads')
-    assert_array_equal(epochs_clean.get_data(), epochs_with_bads_clean.get_data())
+    epochs_with_bads_clean.pick_types(meg=True, eeg=True, eog=True,
+                                      exclude='bads')
+    assert_array_equal(epochs_clean.get_data(),
+                       epochs_with_bads_clean.get_data())
 
     assert_equal(epochs_clean.ch_names, epochs_fit.ch_names)
 
@@ -239,4 +241,3 @@ def test_autoreject():
     threshes_b = compute_thresholds(
         epochs_fit, picks=picks, method='bayesian_optimization')
     assert_equal(set(threshes_b.keys()), set(ch_names))
-

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -203,16 +203,18 @@ def test_autoreject():
     assert_true(not is_same)
 
     # test that transform ignores bad channels
-    picks = mne.pick_types(
+    picks_without_bads = mne.pick_types(
         epochs_with_bads.info, meg='mag', eeg=True, stim=False, eog=False,
-        include=[], exclude=[])
+        include=[], exclude='bads')
     ch_types = ['mag', 'eeg']
-    ar = LocalAutoRejectCV(cv=3, picks=picks, thresh_func=thresh_func,
+    ar = LocalAutoRejectCV(cv=3, picks=picks_without_bads, 
+                           thresh_func=thresh_func,
                            n_interpolate=[1, 2],
                            consensus=[0.5, 1])
     ar.fit(epochs_with_bads_fit)
     epochs_with_bads_clean = ar.transform(epochs_with_bads_fit)
-    epochs_with_bads_clean.pick_channels(pick_channel_names)
+
+    epochs_with_bads_clean.pick_types(meg=True, eeg=True, eog=True, exclude='bads')
     assert_array_equal(epochs_clean.get_data(), epochs_with_bads_clean.get_data())
 
     assert_equal(epochs_clean.ch_names, epochs_fit.ch_names)

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -203,27 +203,28 @@ def test_autoreject():
     assert_true(not is_same)
 
     # test that transform ignores bad channels
-    picks_without_bads = mne.pick_types(
-        epochs_with_bads.info, meg='mag', eeg=True, stim=False, eog=False,
-        include=[], exclude='bads')
-    ar_bads = LocalAutoRejectCV(cv=3, picks=picks_without_bads,
-                                thresh_func=thresh_func,
+    epochs_with_bads_fit.pick_types(meg='mag', eeg=True, eog=True, exclude=[])
+    ar_bads = LocalAutoRejectCV(cv=3, thresh_func=thresh_func,
                                 n_interpolate=[1, 2],
                                 consensus=[0.5, 1])
     ar_bads.fit(epochs_with_bads_fit)
     epochs_with_bads_clean = ar_bads.transform(epochs_with_bads_fit)
 
-    good_ix = mne.pick_types(epochs_with_bads_clean.info,
-                             meg=True, eeg=True, eog=True,
-                             exclude='bads')
-    assert_array_equal(epochs_with_bads_clean.get_data()[:, good_ix, :],
-                       epochs_clean.get_data())
+    good_w_bads_ix = mne.pick_types(epochs_with_bads_clean.info,
+                                    meg='mag', eeg=True, eog=True,
+                                    exclude='bads')
+    good_wo_bads_ix = mne.pick_types(epochs_clean.info,
+                                     meg='mag', eeg=True, eog=True,
+                                     exclude='bads')
+    assert_array_equal(epochs_with_bads_clean.get_data()[:, good_w_bads_ix, :],
+                       epochs_clean.get_data()[:, good_wo_bads_ix, :])
 
     bad_ix = [epochs_with_bads_clean.ch_names.index(ch)
               for ch in epochs_with_bads_clean.info['bads']]
     epo_ix = ~ar_bads.get_reject_log(epochs_with_bads_fit).bad_epochs
-    assert_array_equal(epochs_with_bads_clean._data[:, bad_ix, :],
-                       epochs_with_bads_fit._data[epo_ix, :, :][:, bad_ix, :])
+    assert_array_equal(
+        epochs_with_bads_clean.get_data()[:, bad_ix, :],
+        epochs_with_bads_fit.get_data()[epo_ix, :, :][:, bad_ix, :])
 
     assert_equal(epochs_clean.ch_names, epochs_fit.ch_names)
 

--- a/autoreject/tests/test_utils.py
+++ b/autoreject/tests/test_utils.py
@@ -8,6 +8,8 @@ from mne.datasets import sample
 from mne import io
 
 from autoreject.utils import clean_by_interp, interpolate_bads
+from autoreject.utils import _interpolate_bads_eeg
+import mne.channels.interpolation
 
 from nose.tools import assert_raises
 
@@ -54,3 +56,10 @@ def test_utils():
                            evoked_autoreject.data[picks_bad])
         assert_raises(AssertionError, assert_array_equal,
                       evoked_orig.data[picks_bad], evoked.data[picks_bad])
+
+    # test that autoreject EEG interpolation code behaves the same as MNE
+    evoked_ar = evoked_orig.copy()
+    evoked_mne = evoked_orig.copy()
+    _interpolate_bads_eeg(evoked_ar, picks=None)
+    mne.channels.interpolation._interpolate_bads_eeg(evoked_mne)
+    assert_array_equal(evoked_ar.data, evoked_mne.data)

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -214,8 +214,14 @@ def interpolate_bads(inst, picks, reset_bads=True, mode='accurate'):
     # emerges
     verbose = mne.set_log_level('CRITICAL', return_old_level=True)
 
-    # this needs picks, assume our instance is complete and intact
-    _interpolate_bads_eeg(inst)
+    eeg_picks = set(pick_types(inst.info, meg=False, eeg=True, exclude=[]))
+    eeg_picks_interp = [p for p in picks if p in eeg_picks]
+    if len(eeg_picks_interp) > 0:
+        keep_chs = [inst.ch_names[i] for i in eeg_picks_interp]
+        inst_interp = inst.copy().pick_channels(keep_chs)
+        _interpolate_bads_eeg(inst_interp)
+        inst._data[:, eeg_picks_interp, :] = inst_interp._data
+
     meg_picks = set(pick_types(inst.info, meg=True, eeg=False, exclude=[]))
     meg_picks_interp = [p for p in picks if p in meg_picks]
     if len(meg_picks_interp) > 0:

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -231,7 +231,7 @@ def interpolate_bads(inst, picks, reset_bads=True, mode='accurate'):
     return inst
 
 
-def _interpolate_bads_eeg(inst, picks, verbose=None):
+def _interpolate_bads_eeg(inst, picks=None, verbose=None):
     """ Interpolate bad EEG channels.
 
     Operates in place.
@@ -248,6 +248,9 @@ def _interpolate_bads_eeg(inst, picks, verbose=None):
     from mne.channels.interpolation import _do_interp_dots
     from mne.channels.interpolation import _make_interpolation_matrix
     import numpy as np
+
+    if picks is None:
+        picks = pick_types(inst.info, meg=False, eeg=True, exclude=[])
 
     bads_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
     goods_idx = np.zeros(len(inst.ch_names), dtype=np.bool)

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -208,7 +208,6 @@ def fetch_file(url, file_name, resume=True, timeout=10.):
 def interpolate_bads(inst, picks, reset_bads=True, mode='accurate'):
     """Interpolate bad MEG and EEG channels."""
     import mne
-    from mne.channels.interpolation import _interpolate_bads_eeg
     # to prevent cobyla printf error
     # XXX putting to critical for now unless better solution
     # emerges
@@ -217,13 +216,7 @@ def interpolate_bads(inst, picks, reset_bads=True, mode='accurate'):
     eeg_picks = set(pick_types(inst.info, meg=False, eeg=True, exclude=[]))
     eeg_picks_interp = [p for p in picks if p in eeg_picks]
     if len(eeg_picks_interp) > 0:
-        keep_chs = [inst.ch_names[i] for i in eeg_picks_interp]
-        inst_interp = inst.copy().pick_channels(keep_chs)
-        _interpolate_bads_eeg(inst_interp)
-        if len(inst._data.shape) == 3:
-            inst._data[:, eeg_picks_interp, :] = inst_interp._data
-        elif len(inst._data.shape) == 2:
-            inst._data[eeg_picks_interp, :] = inst_interp._data
+        _interpolate_bads_eeg(inst, picks=eeg_picks_interp)
 
     meg_picks = set(pick_types(inst.info, meg=True, eeg=False, exclude=[]))
     meg_picks_interp = [p for p in picks if p in meg_picks]
@@ -236,6 +229,61 @@ def interpolate_bads(inst, picks, reset_bads=True, mode='accurate'):
     mne.set_log_level(verbose)
 
     return inst
+
+
+def _interpolate_bads_eeg(inst, picks, verbose=None):
+    """ Interpolate bad EEG channels.
+
+    Operates in place.
+
+    Parameters
+    ----------
+    inst : mne.io.Raw, mne.Epochs or mne.Evoked
+        The data to interpolate. Must be preloaded.
+    picks: np.ndarray, shape(n_channels, ) | list | None
+        The channel indices to be used for interpolation.
+    """
+    from mne.bem import _fit_sphere
+    from mne.utils import logger, warn
+    from mne.channels.interpolation import _do_interp_dots
+    from mne.channels.interpolation import _make_interpolation_matrix
+    import numpy as np
+
+    bads_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
+    goods_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
+
+    inst.info._check_consistency()
+    bads_idx[picks] = [inst.ch_names[ch] in inst.info['bads'] for ch in picks]
+
+    if len(picks) == 0 or bads_idx.sum() == 0:
+        return
+
+    goods_idx[picks] = True
+    goods_idx[bads_idx] = False
+
+    pos = inst._get_channel_positions(picks)
+
+    # Make sure only good EEG are used
+    bads_idx_pos = bads_idx[picks]
+    goods_idx_pos = goods_idx[picks]
+    pos_good = pos[goods_idx_pos]
+    pos_bad = pos[bads_idx_pos]
+
+    # test spherical fit
+    radius, center = _fit_sphere(pos_good)
+    distance = np.sqrt(np.sum((pos_good - center) ** 2, 1))
+    distance = np.mean(distance / radius)
+    if np.abs(1. - distance) > 0.1:
+        warn('Your spherical fit is poor, interpolation results are '
+             'likely to be inaccurate.')
+
+    logger.info('Computing interpolation matrix from {0} sensor '
+                'positions'.format(len(pos_good)))
+
+    interpolation = _make_interpolation_matrix(pos_good, pos_bad)
+
+    logger.info('Interpolating {0} sensors'.format(len(pos_bad)))
+    _do_interp_dots(inst, interpolation, goods_idx, bads_idx)
 
 
 def _interpolate_bads_meg_fast(inst, picks, mode='accurate', verbose=None):

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -220,7 +220,11 @@ def interpolate_bads(inst, picks, reset_bads=True, mode='accurate'):
         keep_chs = [inst.ch_names[i] for i in eeg_picks_interp]
         inst_interp = inst.copy().pick_channels(keep_chs)
         _interpolate_bads_eeg(inst_interp)
-        inst._data[:, eeg_picks_interp, :] = inst_interp._data
+        if len(inst._data.shape) == 3:
+            inst._data[:, eeg_picks_interp, :] = inst_interp._data
+        elif len(inst._data.shape) == 2:
+            inst._data[eeg_picks_interp, :] = inst_interp._data
+
 
     meg_picks = set(pick_types(inst.info, meg=True, eeg=False, exclude=[]))
     meg_picks_interp = [p for p in picks if p in meg_picks]

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -225,7 +225,6 @@ def interpolate_bads(inst, picks, reset_bads=True, mode='accurate'):
         elif len(inst._data.shape) == 2:
             inst._data[eeg_picks_interp, :] = inst_interp._data
 
-
     meg_picks = set(pick_types(inst.info, meg=True, eeg=False, exclude=[]))
     meg_picks_interp = [p for p in picks if p in meg_picks]
     if len(meg_picks_interp) > 0:


### PR DESCRIPTION
This is the fix for the issue raised about transform interpolating bad channels back into the data.

I've added a test by comparing autoreject run on data with and without extra bad channels. However, I'm running into a bug that I don't quite understand while trying to pass this test. Autoreject on the copy of the data with bad channels fails on an assertion in line 273 of _interpolate_bads_meg_fast. This assertion seems to be asserting that the bad channels in the sub-selected info and the original info should be the same? I'm not sure why this would be the case. Am I misunderstanding or is this another bug?