### PR TITLE
Add bad sensors count per epochs to reject log

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -1120,3 +1120,18 @@ class RejectLog(object):
             bad_epochs_idx=np.where(self.bad_epochs)[0],
             log_labels=self.labels, scalings=scalings,
             title='')
+
+    def bad_sensors_counts(self):
+        """Get number of bad sensors per epochs.
+
+        Parameters
+        ----------
+
+
+        Returns
+        -------
+        counts : Instance of np.array
+            Number of bad sensors per epoch
+        """
+        return np.sum(
+            np.logical_and(self.labels != 0, ~np.isnan(self.labels)), axis=1)


### PR DESCRIPTION
Hi Team!

I added an option to keep the number of bad channels detected for each epoch in the log. Basically I use this to check the overall quality of the data after cleaning and give the user an idea on how many electrodes were rejected for each epoch, with the possibility to visualise or do stats.

I hope you find it useful.