### PR TITLE
[MRG] autoreject is faster

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -625,7 +625,7 @@ class _AutoReject(BaseAutoReject):
         self.consensus_[ch_type] = self.consensus
 
         self.threshes_ = self.thresh_func(
-            epochs, picks=self.picks_, verbose=self.verbose)
+            epochs.copy(), picks=self.picks_, verbose=self.verbose)
 
         reject_log = self.get_reject_log(epochs=epochs, picks=self.picks_)
 

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -625,7 +625,7 @@ class _AutoReject(BaseAutoReject):
         self.consensus_[ch_type] = self.consensus
 
         self.threshes_ = self.thresh_func(
-            epochs.copy(), picks=self.picks_, verbose=self.verbose)
+            epochs, picks=self.picks_, verbose=self.verbose)
 
         reject_log = self.get_reject_log(epochs=epochs, picks=self.picks_)
 

--- a/autoreject/ransac.py
+++ b/autoreject/ransac.py
@@ -149,7 +149,7 @@ class Ransac(object):
             # don't do the following as it will sort the channels!
             # pick_from = pick_channels(ch_names, ch_subsets[idx])
             pick_from = np.array([ch_names.index(name)
-                                 for name in ch_subsets[idx]])
+                                  for name in ch_subsets[idx]])
             mapping = np.zeros((n_channels, n_channels))
             if self.ch_type == 'meg':
                 mapping[:, pick_from] = _fast_map_meg_channels(

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -413,7 +413,7 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
     verbose = mne.get_config('MNE_LOGGING_LEVEL', 'INFO')
     mne.set_log_level('WARNING')
 
-    def _compute_dots(info, ch_names, mode='fast'):
+    def _compute_dots(info, locs3d, mode='fast'):
         """Compute all-to-all dots."""
         templates = _read_coil_defs()
         coils = _create_meg_coils(info['chs'], 'normal', info['dev_head_t'],
@@ -439,8 +439,9 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
 
     # This function needs a clean input. It hates the presence of other
     # channels than MEG channels. Make sure all is picked.
+    locs3d = np.array([ch['loc'][:3] for ch in info['chs']])
     self_dots, cross_dots = _compute_fast_dots(
-        info, info['ch_names'], mode=mode)
+        info, locs3d, mode=mode)
 
     cross_dots = cross_dots[pick_to, :][:, pick_from]
     self_dots = self_dots[pick_from, :][:, pick_from]

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -378,14 +378,14 @@ def _interpolate_bads_meg_fast(inst, picks, mode='accurate', verbose=None):
     # as the MNE interpolation code is not fogriving.
     # This is why we picked the info.
     mapping = _fast_map_meg_channels(
-        picked_info.copy(), pick_from=picks_good, pick_to=picks_bad,
+        picked_info, pick_from=picks_good, pick_to=picks_bad,
         mode=mode)
     # the downside is that the mapping matrix now does not match
     # the unpicked info of the data.
     # Since we may have picked the info, we need to double map
     # the indices.
     _, picks_good_, picks_bad_orig = get_picks_bad_good(
-        inst.info.copy(), picks)
+        inst.info, picks)
     ch_names_a = [picked_info['ch_names'][pp] for pp in picks_bad]
     ch_names_b = [inst.info['ch_names'][pp] for pp in picks_bad_orig]
     assert ch_names_a == ch_names_b
@@ -428,7 +428,6 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
 
     _compute_fast_dots = mem.cache(_compute_dots, verbose=0,
                                    ignore=['info', 'mode'])
-    info['bads'] = []  # if bads is different, hash will be different
 
     info_from = pick_info(info, pick_from, copy=True)
     templates = _read_coil_defs()

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -413,10 +413,10 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
     verbose = mne.get_config('MNE_LOGGING_LEVEL', 'INFO')
     mne.set_log_level('WARNING')
 
-    def _compute_dots(info, locs3d, mode='fast'):
+    def _compute_dots(info, locs3d, dev_head_t, mode='fast'):
         """Compute all-to-all dots."""
         templates = _read_coil_defs()
-        coils = _create_meg_coils(info['chs'], 'normal', info['dev_head_t'],
+        coils = _create_meg_coils(info['chs'], 'normal', dev_head_t,
                                   templates)
         my_origin = _check_origin((0., 0., 0.04), info_from)
         int_rad, noise, lut_fun, n_fact = _setup_dots(mode, coils, 'meg')
@@ -441,7 +441,7 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
     # channels than MEG channels. Make sure all is picked.
     locs3d = np.array([ch['loc'][:3] for ch in info['chs']])
     self_dots, cross_dots = _compute_fast_dots(
-        info, locs3d, mode=mode)
+        info, locs3d, info['dev_head_t'], mode=mode)
 
     cross_dots = cross_dots[pick_to, :][:, pick_from]
     self_dots = self_dots[pick_from, :][:, pick_from]

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,6 +17,7 @@ Changelog
 
 - Introduced a new method :meth:`autoreject.AutoReject.save` and function :func:`autoreject.read_auto_reject`
   for IO of autoreject objects, by `Mainak Jas`_ in `#120 <https://github.com/autoreject/autoreject/pull/120>`_
+- Make MEG interpolation faster by precomputing dot products for the interpolation, by `Mainak Jas`_
 
 Bug
 ~~~

--- a/examples/plot_visualize_bad_epochs.py
+++ b/examples/plot_visualize_bad_epochs.py
@@ -11,6 +11,8 @@ visualize the bad sensors in each trial
 #         Denis A. Engemann <denis.engemann@gmail.com>
 # License: BSD (3-clause)
 
+# sphinx_gallery_thumbnail_number = 2
+
 ###############################################################################
 # First, we download the data from OpenfMRI. We will download the tarfile,
 # extract the necessary files and delete the tar from the disk


### PR DESCRIPTION
I profiled the code and it seemed to get some gains by changing how joblib does the hashing. I think if you try to hash the `info` object, it gets really slow. It seems to help cut around 30 seconds on the sample data example (!)

But there is a danger with using just the channel names for hashing as it could lead to potential collisions between datasets. One solution could be to use context managers to clean up the joblib directory every time `autoreject` runs ...