### PR TITLE
[MRG] FIX ch_type can be chosen

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -153,7 +153,8 @@ class _GlobalAutoReject(BaseAutoReject):
         return self
 
 
-def get_rejection_threshold(epochs, decim=1, random_state=None, verbose=True):
+def get_rejection_threshold(epochs, decim=1, random_state=None,
+                            ch_types=None, verbose=True):
     """Compute global rejection thresholds.
 
     Parameters
@@ -164,14 +165,17 @@ def get_rejection_threshold(epochs, decim=1, random_state=None, verbose=True):
         The decimation factor.
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use.
+    ch_types : str | list of str | None
+        The channel types for which to find the rejection dictionary.
+        e.g., ['mag', 'grad']. If None, the rejection dictionary
+        will have keys ['mag', 'grad', 'eeg', 'eog'].
     verbose : bool
         If False, suppress all output messages.
 
     Returns
     -------
     reject : dict
-        The rejection dictionary with keys 'mag', 'grad', 'eeg', 'eog'
-        and 'ecg'.
+        The rejection dictionary with keys as specified by ch_types.
 
     Note
     ----
@@ -179,10 +183,20 @@ def get_rejection_threshold(epochs, decim=1, random_state=None, verbose=True):
     rejection dictionary.
     """
     reject = dict()
+
+    if ch_types is not None and not isinstance(ch_types, (list, str)):
+        raise ValueError('ch_types must be of type None, list,'
+                         'or str. Got %s' % type(ch_types))
+
+    if ch_types is None:
+        ch_types = ['mag', 'grad', 'eeg', 'eog']
+    elif isinstance(ch_types, str):
+        ch_types = [ch_types]
+
     if decim > 1:
         epochs = epochs.copy()
         epochs.decimate(decim=decim)
-    for ch_type in ['mag', 'grad', 'eeg', 'eog']:
+    for ch_type in ch_types:
         if ch_type not in epochs:
             continue
 

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -54,6 +54,11 @@ def test_global_autoreject():
         assert_equal(reject1[key], reject2[key])
         assert_true(abs(reject1[key] - reject3[key]) < tols[key])
 
+    reject = get_rejection_threshold(epochs, decim=4, ch_types='eeg')
+    assert 'eog' not in reject
+    assert_raises(ValueError, get_rejection_threshold, epochs,
+                  decim=4, ch_types=5)
+
 
 def test_autoreject():
     """Test basic _AutoReject functionality."""

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -56,6 +56,7 @@ def test_global_autoreject():
 
     reject = get_rejection_threshold(epochs, decim=4, ch_types='eeg')
     assert 'eog' not in reject
+    assert 'eeg' in reject
     assert_raises(ValueError, get_rejection_threshold, epochs,
                   decim=4, ch_types=5)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,4 +30,7 @@ Bug
 API
 ~~~
 
+- Added `ch_types` argument to :func:`autoreject.get_rejection_threshold` to find
+  rejection thresholds for only subset of channel types in the data, by `Mainak Jas` in `#140 <https://github.com/autoreject/autoreject/pull/140>`_
+
 .. _Mainak Jas: https://perso.telecom-paristech.fr/mjas/


### PR DESCRIPTION
closes #139

I have added a param ch_types so you can save time if you don't want rejection threshold for all channel types. Okay for you @agramfort @dengemann ? I find it useful as sometimes I don't want to reject based on EOG (e.g., for ICA), so I end up popping it from the dictionary in the end. But it wastes computation.