### PR TITLE
[MRG] Extend documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install coverage
   - python setup.py install
 script:
-  - nosetests . --with-coverage
+  - nosetests ./autoreject --with-coverage
   - flake8 --count .
   - check-manifest --ignore .circleci*,doc
 after_success:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,7 +128,7 @@ html_theme_options = {
     'navbar_sidebarrel': False,
     'navbar_links': [
         ("Examples", "auto_examples/index"),
-        ("Explanation", "explanation",)
+        ("Explanation", "explanation"),
         ("FAQ", "faq"),
         ("API", "api"),
         ("What's new", "whats_new"),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -307,7 +307,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/', None),
-                       'seaborn': ('https://web.stanford.edu/~mwaskom/software/seaborn/', None),  # noqa: E501
+                       'seaborn': ('https://seaborn.pydata.org/', None),
                        'mne': ('http://martinos.org/mne/stable/', None)
                        }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,8 +128,9 @@ html_theme_options = {
     'navbar_sidebarrel': False,
     'navbar_links': [
         ("Examples", "auto_examples/index"),
-        ("API", "api"),
+        ("Explanation", "explanation",)
         ("FAQ", "faq"),
+        ("API", "api"),
         ("What's new", "whats_new"),
         ("GitHub", "https://github.com/autoreject/autoreject", True)
     ],

--- a/doc/explanation.rst
+++ b/doc/explanation.rst
@@ -1,0 +1,35 @@
+Explanations
+============
+
+This section of the documentation exists to illuminate how ``autoreject`` works.
+The primary source for understanding should be the original publication [1]_,
+however the sections in this guide can make the content of that primary source
+more graspable.
+
+
+Intuition on how the - *autoreject global* - algorithm works
+------------------------------------------------------------
+- Given some data with multiple trials (epochs) that contain sensor X timepoints data
+- We want to find a threshold T in microvolts that will reject noisy epochs and retain clean epochs
+- Do the following for a set of possible candidate thresholds Ts
+- For each T:
+    - Split your data into K folds (=k equal parts) along the trial dimension
+        - Each of the k parts will be a "test" set once, while the others will be combined to be a "train" set
+    - Then for each fold k (consisting of train and test trials) do:
+        - apply threshold T to reject trials in the train set
+        - calculate the mean of the signal (for each sensor and timepoint) over the GOOD trials in the train set
+        - calculate the *median* of the signal (for each sensor and timepoint) over ALL trials in the test set
+        - compare both of these signals and calculate the error (frobenius norm of their difference)
+        - save the error
+    - Now we have k errors
+    - Form the mean error (over all k errors) associated with our current threshold T in microvolts
+    - Save the mapping of current T to its error
+
+- ... now we have a set of Ts all mapped to their specific error
+- the T with the lowest error is the best rejection threshold for a global rejection
+
+References
+----------
+.. [1] Mainak Jas, Denis Engemann, Yousra Bekhti, Federico Raimondo, and
+   Alexandre Gramfort. 2017. Autoreject: Automated artifact rejection for MEG
+   and EEG data. NeuroImage, 159, 417-429.

--- a/doc/explanation.rst
+++ b/doc/explanation.rst
@@ -1,5 +1,5 @@
-Explanations
-============
+Explanation
+===========
 
 This section of the documentation exists to illuminate how ``autoreject`` works.
 The primary source for understanding should be the original publication [1]_,
@@ -9,35 +9,51 @@ more graspable.
 
 Intuition on how the - *autoreject global* - algorithm works
 ------------------------------------------------------------
+
 - Given some MEEG data :math:`X` with the dimensions
   :math:`trials(=epochs) \times sensors \times timepoints`
-- We want to find a threshold :math:`\phi` in :math:`\mu V` that will reject
+
+- We want to find a threshold :math:`\tau` in :math:`\mu V` that will reject
   noisy epochs and retain clean epochs
+
 - Do the following for a set of possible candidate thresholds: :math:`\Phi`
-- For each :math:`\phi_i \in \Phi` :
-    - Split your data :math:`X` into :math:`K` folds (=:math:`K` equal parts)
-      along the trial dimension
-        - Each of the :math:`K` parts will be a "test" set once, while the
-          remaining :math:`K-1` parts will be combined to be the corresponding
-           "train" set (see `k-fold crossvalidation <https://en.wikipedia.org/wiki/Cross-validation_(statistics)#k-fold_cross-validation>`_)
-    - Then for each fold :math:`K` (consisting of train and test trials) do:
-        - apply threshold :math:`\phi_i` to reject trials in the train set
-        - calculate the mean of the signal (for each sensor and timepoint) over
-          the GOOD (=not rejected) trials in the train set
-        - calculate the *median* of the signal (for each sensor and timepoint)
-          over ALL trials in the test set
-        - compare both of these signals and calculate the error :math:`e_k`
-          (i.e., take the `Frobenius norm <https://en.wikipedia.org/wiki/Matrix_norm#Frobenius_norm>`_
-          of their difference)
-        - save that error :math:`e_k`
-    - Now we have :math:`K` errors :math:`e_k  \in E`
-    - Form the mean error :math:`\bar E` (over all :math:`K` errors) associated
-      with our current threshold :math:`\phi_i` in :math:`\mu V`
-    - Save the mapping of :math:`\phi_i` to its associated error :math:`\bar E`
+
+- For each :math:`\tau_i \in \Phi` :
+
+  - Split your data :math:`X` into :math:`K` folds (:math:`K` equal parts)
+    along the trial dimension
+
+    - Each of the :math:`K` parts will be a "test" set once, while the
+      remaining :math:`K-1` parts will be combined to be the corresponding
+      "train" set (see `k-fold crossvalidation <https://en.wikipedia.org/wiki/Cross-validation_(statistics)#k-fold_cross-validation>`_)
+
+  - Then for each fold :math:`K` (consisting of train and test trials) do:
+
+    - apply threshold :math:`\tau_i` to reject trials in the train set
+
+    - calculate the mean of the signal (for each sensor and timepoint) over
+      the GOOD (=not rejected) trials in the train set
+
+    - calculate the *median* of the signal (for each sensor and timepoint)
+      over ALL trials in the test set
+
+    - compare both of these signals and calculate the error :math:`e_k`
+      (i.e., take the `Frobenius norm <https://en.wikipedia.org/wiki/Matrix_norm#Frobenius_norm>`_
+      of their difference)
+
+    - save that error :math:`e_k`
+
+  - Now we have :math:`K` errors :math:`e_k  \in E`
+
+  - Form the mean error :math:`\bar E` (over all :math:`K` errors) associated
+    with our current threshold :math:`\tau_i` in :math:`\mu V`
+
+  - Save the mapping of :math:`\tau_i` to its associated error :math:`\bar E`
 
 - ... now each threshold candidate in the set :math:`\Phi` is mapped to a
   specific error value :math:`\bar E`
-- the candidate threshold :math:`\phi_i` with the lowest error is the best
+
+- the candidate threshold :math:`\tau_i` with the lowest error is the best
   rejection threshold for a global rejection
 
 References

--- a/doc/explanation.rst
+++ b/doc/explanation.rst
@@ -9,24 +9,36 @@ more graspable.
 
 Intuition on how the - *autoreject global* - algorithm works
 ------------------------------------------------------------
-- Given some data with multiple trials (epochs) that contain sensor X timepoints data
-- We want to find a threshold T in microvolts that will reject noisy epochs and retain clean epochs
-- Do the following for a set of possible candidate thresholds Ts
-- For each T:
-    - Split your data into K folds (=k equal parts) along the trial dimension
-        - Each of the k parts will be a "test" set once, while the others will be combined to be a "train" set
-    - Then for each fold k (consisting of train and test trials) do:
-        - apply threshold T to reject trials in the train set
-        - calculate the mean of the signal (for each sensor and timepoint) over the GOOD trials in the train set
-        - calculate the *median* of the signal (for each sensor and timepoint) over ALL trials in the test set
-        - compare both of these signals and calculate the error (frobenius norm of their difference)
-        - save the error
-    - Now we have k errors
-    - Form the mean error (over all k errors) associated with our current threshold T in microvolts
-    - Save the mapping of current T to its error
+- Given some MEEG data :math:`X` with the dimensions
+  :math:`trials(=epochs) \times sensors \times timepoints`
+- We want to find a threshold :math:`\phi` in :math:`\mu V` that will reject
+  noisy epochs and retain clean epochs
+- Do the following for a set of possible candidate thresholds: :math:`\Phi`
+- For each :math:`\phi_i \in \Phi` :
+    - Split your data :math:`X` into :math:`K` folds (=:math:`K` equal parts)
+      along the trial dimension
+        - Each of the :math:`K` parts will be a "test" set once, while the
+          remaining :math:`K-1` parts will be combined to be the corresponding
+           "train" set (see `k-fold crossvalidation <https://en.wikipedia.org/wiki/Cross-validation_(statistics)#k-fold_cross-validation>`_)
+    - Then for each fold :math:`K` (consisting of train and test trials) do:
+        - apply threshold :math:`\phi_i` to reject trials in the train set
+        - calculate the mean of the signal (for each sensor and timepoint) over
+          the GOOD (=not rejected) trials in the train set
+        - calculate the *median* of the signal (for each sensor and timepoint)
+          over ALL trials in the test set
+        - compare both of these signals and calculate the error :math:`e_k`
+          (i.e., take the `Frobenius norm <https://en.wikipedia.org/wiki/Matrix_norm#Frobenius_norm>`_
+          of their difference)
+        - save that error :math:`e_k`
+    - Now we have :math:`K` errors :math:`e_k  \in E`
+    - Form the mean error :math:`\bar E` (over all :math:`K` errors) associated
+      with our current threshold :math:`\phi_i` in :math:`\mu V`
+    - Save the mapping of :math:`\phi_i` to its associated error :math:`\bar E`
 
-- ... now we have a set of Ts all mapped to their specific error
-- the T with the lowest error is the best rejection threshold for a global rejection
+- ... now each threshold candidate in the set :math:`\Phi` is mapped to a
+  specific error value :math:`\bar E`
+- the candidate threshold :math:`\phi_i` with the lowest error is the best
+  rejection threshold for a global rejection
 
 References
 ----------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -1,6 +1,9 @@
 Frequently asked questions
 ==========================
 
+This section of the documentation provides a *discussion-like* format, answering
+"How-to" questions.
+
 Should I apply ICA first or autoreject first?
 ---------------------------------------------
 
@@ -49,7 +52,7 @@ as a list of a single element::
 
 	>>> ar = AutoReject(n_interpolate=[1], consensus_percs=[0.6])
 
-Note this will still run a cross-validation loop to generate the 
+Note this will still run a cross-validation loop to generate the
 validation score.
 
 Is it possible to get only bad sensor annotations and not interpolate?

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -3,6 +3,9 @@
 Examples Gallery
 ================
 
+This section of the documentation is learning-oriented and shows off some of
+the basic functionality of ``autoreject``.
+
 .. contents:: Contents
    :local:
    :depth: 3


### PR DESCRIPTION
closes #144 

Based on our discussion in #144 I try to put the "intuition" on autoreject global into a new section of the docs.

I think that this `explanations` section can grow over time and that it is a bit like the last "missing" part, when considering this [seminal pycon australia talk](https://www.divio.com/blog/documentation/) (link leads to associated blogpost)

![image](https://user-images.githubusercontent.com/9084751/58974484-c761ee80-87c2-11e9-96d1-70a51efe9f24.png)


I see:
- "learning oriented" covered by /examples
- "Problem oriented" covered by FAQ
- "understanding oriented" covered through this PR
- "information oriented" covered by the API

Note: The actual text in `explanation.rst` is still WIP, but I wanted your input on the structure before continuing to work on it.
