### PR TITLE
add project urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env python
 """Setup autoreject."""
 import os
-import setuptools  # noqa; we are using a setuptools namespace
-from numpy.distutils.core import setup
+from setuptools import setup, find_packages
 
 # get the version (don't import autoreject here to avoid dependency)
 version = None
@@ -21,6 +20,7 @@ DESCRIPTION = descr
 MAINTAINER = 'Mainak Jas'
 MAINTAINER_EMAIL = 'mainakjas@gmail.com'
 LICENSE = 'BSD (3-clause)'
+URL = 'http://autoreject.github.io/'
 DOWNLOAD_URL = 'https://github.com/autoreject/autoreject.git'
 VERSION = version
 
@@ -31,6 +31,7 @@ if __name__ == "__main__":
           description=DESCRIPTION,
           license=LICENSE,
           version=VERSION,
+          url=URL,
           download_url=DOWNLOAD_URL,
           long_description=open('README.rst').read(),
           long_description_content_type='text/x-rst',
@@ -47,9 +48,9 @@ if __name__ == "__main__":
               'Operating System :: MacOS',
           ],
           platforms='any',
-          packages=[
-              'autoreject'
-          ],
+          keywords=('electroencephalography eeg magnetoencephalography '
+                    'meg preprocessing analysis'),
+          packages=find_packages(),
           project_urls={'Documentation': 'http://autoreject.github.io/',
                         'Bug Reports': 'https://github.com/autoreject/autoreject/issues',  # noqa: E501
                         'Source': 'https://github.com/autoreject/autoreject'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+"""Setup autoreject."""
 import os
 import setuptools  # noqa; we are using a setuptools namespace
 from numpy.distutils.core import setup
@@ -32,6 +33,7 @@ if __name__ == "__main__":
           version=VERSION,
           download_url=DOWNLOAD_URL,
           long_description=open('README.rst').read(),
+          long_description_content_type='text/x-rst',
           classifiers=[
               'Intended Audience :: Science/Research',
               'Intended Audience :: Developers',
@@ -48,4 +50,8 @@ if __name__ == "__main__":
           packages=[
               'autoreject'
           ],
+          project_urls={'Documentation': 'http://autoreject.github.io/',
+                        'Bug Reports': 'https://github.com/autoreject/autoreject/issues',  # noqa: E501
+                        'Source': 'https://github.com/autoreject/autoreject'
+                        }
           )


### PR DESCRIPTION
The changes here will change how `autoreject` looks on pypi. Currently, we see the following (see on [pypi](https://pypi.org/project/autoreject/)):

![image](https://user-images.githubusercontent.com/9084751/60127920-b4bf5180-9791-11e9-8980-ea8ecd671d62.png)

With the changes, this will look as such:

![image](https://user-images.githubusercontent.com/9084751/60127902-a3764500-9791-11e9-8014-c62024173146.png)

... except for the "Homepage" link (for that, one would have to set a `URL` field, similar to `DOWNLOAD_URL`)

This will invite users to check out the different pages.