### PR TITLE
provide link to latest docs as built by circleci

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ This repository hosts code to automatically reject trials and repair sensors for
 
 The documentation can be found under the following links:
 
-- for the `stable release < https://autoreject.github.io/>`_
+- for the `stable release <https://autoreject.github.io/>`_
 - for the `latest (development) version <https://circleci.com/api/v1.1/project/github/autoreject/autoreject/latest/artifacts/0/html/index.html?branch=master>`_
 
 Dependencies

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,12 @@ This repository hosts code to automatically reject trials and repair sensors for
 
 .. image:: http://autoreject.github.io/_images/sphx_glr_plot_visualize_bad_epochs_002.png
 
+
+The documentation can be found under the following links:
+
+- for the `stable release < https://autoreject.github.io/>`_
+- for the `latest (development) version <https://circleci.com/api/v1.1/project/github/autoreject/autoreject/latest/artifacts/0/html/index.html?branch=master>`_
+
 Dependencies
 ------------
 


### PR DESCRIPTION
Using the CircleCi build of autoreject, we can provide a link to the "latest" docs. Similar to how we do it with MNE-BIDS.


rendered: https://github.com/autoreject/autoreject/blob/f301ecc444db2d29435c71a4b91f31eeade3ef9d/README.rst