### PR TITLE
MRG MAINT: update test using _interpolate_bads_eeg to use origin

### DIFF
--- a/autoreject/tests/test_utils.py
+++ b/autoreject/tests/test_utils.py
@@ -1,7 +1,7 @@
 # Author: Mainak Jas <mainak.jas@telecom-paristech.fr>
 # License: BSD (3-clause)
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 import mne
 from mne.datasets import sample
@@ -65,7 +65,7 @@ def test_utils():
     origin = _check_origin('auto', evoked_ar.info)
     _interpolate_bads_eeg(evoked_ar, picks=None)
     mne.channels.interpolation._interpolate_bads_eeg(evoked_mne, origin=origin)
-    assert_array_equal(evoked_ar.data, evoked_mne.data)
+    assert_array_almost_equal(evoked_ar.data, evoked_mne.data)
 
 
 def test_interpolate_bads():

--- a/autoreject/tests/test_utils.py
+++ b/autoreject/tests/test_utils.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_array_equal
 
 import mne
 from mne.datasets import sample
+from mne.bem import _check_origin
 from mne import io
 
 from autoreject.utils import clean_by_interp, interpolate_bads
@@ -60,8 +61,10 @@ def test_utils():
     # test that autoreject EEG interpolation code behaves the same as MNE
     evoked_ar = evoked_orig.copy()
     evoked_mne = evoked_orig.copy()
+
+    origin = _check_origin('auto', evoked_ar.info)
     _interpolate_bads_eeg(evoked_ar, picks=None)
-    mne.channels.interpolation._interpolate_bads_eeg(evoked_mne)
+    mne.channels.interpolation._interpolate_bads_eeg(evoked_mne, origin=origin)
     assert_array_equal(evoked_ar.data, evoked_mne.data)
 
 


### PR DESCRIPTION
closes #160 

@agramfort the test will fail now because there were some changes made on the MNE end. Not sure if we should also update the interpolation code inside `autoreject` or not.