### PR TITLE
Drop NOSE module in favor of PYTEST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage.xml
 *.pyc
 *.so
 *.pyd

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 script:
   - pytest ./autoreject --cov=./autoreject --cov-report=xml --verbose
   - flake8 --count .
-  - check-manifest --ignore .circleci*, doc
+  - check-manifest --ignore .circleci*,doc
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,13 @@ install:
   - conda create -n testenv --yes pip python=${PYTHON_VERSION}
   - source activate testenv
   - conda install --yes --quiet numpy scipy scikit-learn matplotlib joblib
-  - conda install --yes --quiet nose coverage
+  - pip install pytest pytest-cov pytest-sugar pytest-faulthandler
   - pip install -q flake8 check-manifest h5py
   - pip install https://api.github.com/repos/mne-tools/mne-python/zipball/master
-  - pip install coverage
   - python setup.py install
 script:
-  - nosetests ./autoreject --with-coverage
+  - pytest ./autoreject --cov=./autoreject --cov-report=xml --verbose
   - flake8 --count .
-  - check-manifest --ignore .circleci*,doc
+  - check-manifest --ignore .circleci*, doc
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@
 
 PYTHON ?= python
 CYTHON ?= cython
-NOSETESTS ?= nosetests
-NOSETESTS_OPTIONS := $(shell pip list | grep nose-timer > /dev/null && \
-                       echo '--with-timer --timer-top-n 50')
 CTAGS ?= ctags
 
 all: clean test doc-noplot
@@ -32,15 +29,13 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 test-code:
-	$(NOSETESTS) -s autoreject $(NOSETESTS_OPTIONS)
+	pytest ./autoreject
 test-doc:
-	$(NOSETESTS) -s --with-doctest --doctest-tests --doctest-extension=rst \
-	--doctest-extension=inc --doctest-fixtures=_fixture `find doc/ -name '*.rst'`
+	pytest --doctest-glob='.rst'
 
 test-coverage:
-	rm -rf coverage .coverage
-	$(NOSETESTS) -s --with-coverage --cover-html --cover-html-dir=coverage \
-	--cover-package=autoreject autoreject
+	rm -rf .coverage
+	pytest --cov=autoreject/tests
 
 test-manifest:
 	check-manifest --ignore doc;

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -49,10 +49,10 @@ def test_global_autoreject():
     reject2 = get_rejection_threshold(epochs, decim=1, random_state=42)
     reject3 = get_rejection_threshold(epochs, decim=2, random_state=42)
     tols = dict(eeg=5e-6, eog=5e-6, grad=10e-12, mag=5e-15)
-    assert_true(reject1, isinstance(reject1, dict))
+    assert reject1, isinstance(reject1, dict)
     for key, value in list(reject1.items()):
-        assert_equal(reject1[key], reject2[key])
-        assert_true(abs(reject1[key] - reject3[key]) < tols[key])
+        assert reject1[key] == reject2[key]
+        assert abs(reject1[key] - reject3[key]) < tols[key]
 
     reject = get_rejection_threshold(epochs, decim=4, ch_types='eeg')
     assert 'eog' not in reject
@@ -81,7 +81,7 @@ def test_autoreject():
     epochs.load_data()
 
     ar.fit(epochs)
-    assert_true(len(ar.picks_) == len(picks) - 1)
+    assert len(ar.picks_) == len(picks) - 1
 
     # epochs with no picks.
     epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
@@ -162,16 +162,12 @@ def test_autoreject():
     reject_log = ar.get_reject_log(epochs_fit)
     for ch_type in ch_types:
         # test that kappa & rho are selected
-        assert_true(
-            ar.n_interpolate_[ch_type] in ar.n_interpolate)
-        assert_true(
-            ar.consensus_[ch_type] in ar.consensus)
+        assert ar.n_interpolate_[ch_type] in ar.n_interpolate
+        assert ar.consensus_[ch_type] in ar.consensus
 
-        assert_true(
-            ar.n_interpolate_[ch_type] ==
+        assert (ar.n_interpolate_[ch_type] ==
             ar.local_reject_[ch_type].n_interpolate_[ch_type])
-        assert_true(
-            ar.consensus_[ch_type] ==
+        assert (ar.consensus_[ch_type] ==
             ar.local_reject_[ch_type].consensus_[ch_type])
 
     # test complementarity of goods and bads
@@ -179,8 +175,8 @@ def test_autoreject():
 
     # test that transform does not change state of ar
     epochs_clean = ar.transform(epochs_fit)  # apply same data
-    assert_true(repr(ar))
-    assert_true(repr(ar.local_reject_))
+    assert repr(ar)
+    assert repr(ar.local_reject_)
     reject_log2 = ar.get_reject_log(epochs_fit)
     assert_array_equal(reject_log.labels, reject_log2.labels)
     assert_array_equal(reject_log.bad_epochs, reject_log2.bad_epochs)
@@ -191,16 +187,13 @@ def test_autoreject():
     reject_log_new = ar.get_reject_log(epochs_new)
     assert_array_equal(len(reject_log_new.bad_epochs), len(epochs_new))
 
-    assert_true(
-        len(reject_log_new.bad_epochs) != len(reject_log.bad_epochs))
+    assert len(reject_log_new.bad_epochs) != len(reject_log.bad_epochs)
 
     picks_by_type = _get_picks_by_type(epochs.info, ar.picks)
     # test correct entries in fix log
-    assert_true(
-        np.isnan(reject_log_new.labels[:, non_picks]).sum() > 0)
-    assert_true(
-        np.isnan(reject_log_new.labels[:, picks]).sum() == 0)
-    assert_equal(reject_log_new.labels.shape,
+    assert np.isnan(reject_log_new.labels[:, non_picks]).sum() > 0
+    assert np.isnan(reject_log_new.labels[:, picks]).sum() == 0
+    assert (reject_log_new.labels.shape ==
                  (len(epochs_new), len(epochs_new.ch_names)))
 
     # test correct interpolations by type
@@ -218,7 +211,7 @@ def test_autoreject():
     is_same = epochs_new_clean.get_data() == epochs_new.get_data()
     if not np.isscalar(is_same):
         is_same = np.isscalar(is_same)
-    assert_true(not is_same)
+    assert not is_same
 
     # test that transform ignores bad channels
     epochs_with_bads_fit.pick_types(meg='mag', eeg=True, eog=True, exclude=[])
@@ -243,13 +236,13 @@ def test_autoreject():
         epochs_with_bads_clean.get_data()[:, bad_ix, :],
         epochs_with_bads_fit.get_data()[epo_ix, :, :][:, bad_ix, :])
 
-    assert_equal(epochs_clean.ch_names, epochs_fit.ch_names)
+    assert epochs_clean.ch_names == epochs_fit.ch_names
 
-    assert_true(isinstance(ar.threshes_, dict))
-    assert_true(len(ar.picks) == len(picks))
-    assert_true(len(ar.threshes_.keys()) == len(ar.picks))
+    assert isinstance(ar.threshes_, dict)
+    assert len(ar.picks) == len(picks)
+    assert len(ar.threshes_.keys()) == len(ar.picks)
     pick_eog = mne.pick_types(epochs.info, meg=False, eeg=False, eog=True)[0]
-    assert_true(epochs.ch_names[pick_eog] not in ar.threshes_.keys())
+    assert epochs.ch_names[pick_eog] not in ar.threshes_.keys()
     assert_raises(
         IndexError, ar.transform,
         epochs.copy().pick_channels(
@@ -261,10 +254,10 @@ def test_autoreject():
                             for ii, pp in enumerate(picks)])
     threshes_a = compute_thresholds(
         epochs_fit, picks=picks, method='random_search')
-    assert_equal(set(threshes_a.keys()), set(ch_names))
+    assert set(threshes_a.keys()) == set(ch_names)
     threshes_b = compute_thresholds(
         epochs_fit, picks=picks, method='bayesian_optimization')
-    assert_equal(set(threshes_b.keys()), set(ch_names))
+    assert set(threshes_b.keys()) == set(ch_names)
 
 
 def test_io():
@@ -292,8 +285,8 @@ def test_io():
     ar2 = read_auto_reject(fname)
     ar.fit(epochs)
     ar2.fit(epochs)
-    assert_equal(np.sum([ar.threshes_[k] - ar2.threshes_[k]
-                         for k in ar.threshes_.keys()]), 0.)
+    assert np.sum([ar.threshes_[k] - ar2.threshes_[k]
+                         for k in ar.threshes_.keys()]) == 0.
 
     assert_raises(ValueError, ar.save, fname)
     ar.save(fname, overwrite=True)

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -18,7 +18,7 @@ from autoreject import (_GlobalAutoReject, _AutoReject, AutoReject,
 from autoreject.utils import _get_picks_by_type
 from autoreject.autoreject import _get_interp_chs
 
-from nose.tools import assert_raises, assert_true, assert_equal
+from nose.tools import pytest.raises, assert_true, assert_equal
 
 import matplotlib
 matplotlib.use('Agg')
@@ -57,7 +57,7 @@ def test_global_autoreject():
     reject = get_rejection_threshold(epochs, decim=4, ch_types='eeg')
     assert 'eog' not in reject
     assert 'eeg' in reject
-    assert_raises(ValueError, get_rejection_threshold, epochs,
+    pytest.raises(ValueError, get_rejection_threshold, epochs,
                   decim=4, ch_types=5)
 
 
@@ -77,7 +77,7 @@ def test_autoreject():
                         reject=None, preload=False)[:10]
 
     ar = _AutoReject()
-    assert_raises(ValueError, ar.fit, epochs)
+    pytest.raises(ValueError, ar.fit, epochs)
     epochs.load_data()
 
     ar.fit(epochs)
@@ -110,11 +110,11 @@ def test_autoreject():
     X = X.reshape(n_epochs, -1)
 
     ar = _GlobalAutoReject()
-    assert_raises(ValueError, ar.fit, X)
+    pytest.raises(ValueError, ar.fit, X)
     ar = _GlobalAutoReject(n_channels=n_channels)
-    assert_raises(ValueError, ar.fit, X)
+    pytest.raises(ValueError, ar.fit, X)
     ar = _GlobalAutoReject(n_times=n_times)
-    assert_raises(ValueError, ar.fit, X)
+    pytest.raises(ValueError, ar.fit, X)
     ar_global = _GlobalAutoReject(
         n_channels=n_channels, n_times=n_times, thresh=40e-6)
     ar_global.fit(X)
@@ -129,7 +129,7 @@ def test_autoreject():
         validation_curve(epochs_fit, return_param_range=True)
     assert len(train_scores) == len(test_scores) == len(param_range)
 
-    assert_raises(ValueError, validation_curve, X, param_range=param_range)
+    pytest.raises(ValueError, validation_curve, X, param_range=param_range)
 
     ##########################################################################
     # picking AutoReject
@@ -146,17 +146,17 @@ def test_autoreject():
 
     ar = AutoReject(cv=3, picks=picks, random_state=42,
                     n_interpolate=[1, 2], consensus=[0.5, 1])
-    assert_raises(AttributeError, ar.fit, X)
-    assert_raises(ValueError, ar.transform, X)
-    assert_raises(ValueError, ar.transform, epochs)
+    pytest.raises(AttributeError, ar.fit, X)
+    pytest.raises(ValueError, ar.transform, X)
+    pytest.raises(ValueError, ar.transform, epochs)
     epochs_nochs = epochs_fit.copy()
     for ch in epochs_nochs.info['chs']:
         ch['loc'] = np.zeros(9)
-    assert_raises(RuntimeError, ar.fit, epochs_nochs)
+    pytest.raises(RuntimeError, ar.fit, epochs_nochs)
     ar2 = AutoReject(cv=3, picks=picks, random_state=42,
                      n_interpolate=[1, 2], consensus=[0.5, 1],
                      verbose='blah')
-    assert_raises(ValueError, ar2.fit, epochs_fit)
+    pytest.raises(ValueError, ar2.fit, epochs_fit)
 
     ar.fit(epochs_fit)
     reject_log = ar.get_reject_log(epochs_fit)
@@ -243,13 +243,13 @@ def test_autoreject():
     assert len(ar.threshes_.keys()) == len(ar.picks)
     pick_eog = mne.pick_types(epochs.info, meg=False, eeg=False, eog=True)[0]
     assert epochs.ch_names[pick_eog] not in ar.threshes_.keys()
-    assert_raises(
+    pytest.raises(
         IndexError, ar.transform,
         epochs.copy().pick_channels(
             [epochs.ch_names[pp] for pp in picks[:3]]))
 
     epochs.load_data()
-    assert_raises(ValueError, compute_thresholds, epochs, 'dfdfdf')
+    pytest.raises(ValueError, compute_thresholds, epochs, 'dfdfdf')
     index, ch_names = zip(*[(ii, epochs_fit.ch_names[pp])
                             for ii, pp in enumerate(picks)])
     threshes_a = compute_thresholds(
@@ -288,7 +288,7 @@ def test_io():
     assert np.sum([ar.threshes_[k] - ar2.threshes_[k]
                          for k in ar.threshes_.keys()]) == 0.
 
-    assert_raises(ValueError, ar.save, fname)
+    pytest.raises(ValueError, ar.save, fname)
     ar.save(fname, overwrite=True)
     ar3 = read_auto_reject(fname)
     epochs_clean1, reject_log1 = ar.transform(epochs, return_log=True)

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -6,6 +6,7 @@ import os.path as op
 
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
 
 import mne
 from mne.datasets import sample
@@ -17,8 +18,6 @@ from autoreject import (_GlobalAutoReject, _AutoReject, AutoReject,
                         get_rejection_threshold, read_auto_reject)
 from autoreject.utils import _get_picks_by_type
 from autoreject.autoreject import _get_interp_chs
-
-from nose.tools import pytest.raises, assert_true, assert_equal
 
 import matplotlib
 matplotlib.use('Agg')

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -165,9 +165,9 @@ def test_autoreject():
         assert ar.consensus_[ch_type] in ar.consensus
 
         assert (ar.n_interpolate_[ch_type] ==
-            ar.local_reject_[ch_type].n_interpolate_[ch_type])
+                ar.local_reject_[ch_type].n_interpolate_[ch_type])
         assert (ar.consensus_[ch_type] ==
-            ar.local_reject_[ch_type].consensus_[ch_type])
+                ar.local_reject_[ch_type].consensus_[ch_type])
 
     # test complementarity of goods and bads
     assert_array_equal(len(reject_log.bad_epochs), len(epochs_fit))
@@ -193,7 +193,7 @@ def test_autoreject():
     assert np.isnan(reject_log_new.labels[:, non_picks]).sum() > 0
     assert np.isnan(reject_log_new.labels[:, picks]).sum() == 0
     assert (reject_log_new.labels.shape ==
-                 (len(epochs_new), len(epochs_new.ch_names)))
+            (len(epochs_new), len(epochs_new.ch_names)))
 
     # test correct interpolations by type
     for ch_type, this_picks in picks_by_type:
@@ -285,7 +285,7 @@ def test_io():
     ar.fit(epochs)
     ar2.fit(epochs)
     assert np.sum([ar.threshes_[k] - ar2.threshes_[k]
-                         for k in ar.threshes_.keys()]) == 0.
+                   for k in ar.threshes_.keys()]) == 0.
 
     pytest.raises(ValueError, ar.save, fname)
     ar.save(fname, overwrite=True)

--- a/autoreject/tests/test_bayesopt.py
+++ b/autoreject/tests/test_bayesopt.py
@@ -15,4 +15,4 @@ def test_bayesopt():
     all_x = np.arange(0., 2.1, 0.1)
     best_x, _ = bayes_opt(func, initial_x, all_x, expected_improvement,
                           max_iter=10, debug=False)
-    assert_true(best_x - x_star < 0.01)
+    assert best_x - x_star < 0.01

--- a/autoreject/tests/test_bayesopt.py
+++ b/autoreject/tests/test_bayesopt.py
@@ -1,11 +1,9 @@
 import numpy as np
-from nose.tools import assert_true
 from autoreject.bayesopt import bayes_opt, expected_improvement
 
 
 def test_bayesopt():
     """Test for bayesian optimization."""
-
     x_star = 1.1
 
     def func(x):

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -35,7 +35,7 @@ def test_ransac():
 
     ransac = Ransac(picks=picks)
     epochs_clean = ransac.fit_transform(epochs)
-    assert_true(len(epochs_clean) == len(epochs))
+    assert len(epochs_clean) == len(epochs)
     # Pass numpy instead of epochs
     X = epochs.get_data()
     assert_raises(AttributeError, ransac.fit, X)

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -7,7 +7,7 @@ from mne import io
 
 from autoreject import Ransac
 
-from nose.tools import assert_raises, assert_true
+from nose.tools import pytest.raises, assert_true
 
 import matplotlib
 matplotlib.use('Agg')
@@ -38,16 +38,16 @@ def test_ransac():
     assert len(epochs_clean) == len(epochs)
     # Pass numpy instead of epochs
     X = epochs.get_data()
-    assert_raises(AttributeError, ransac.fit, X)
+    pytest.raises(AttributeError, ransac.fit, X)
     #
     # should not contain both channel types
     picks = mne.pick_types(epochs.info, meg=True, eeg=False, stim=False,
                            eog=False, exclude=[])
     ransac = Ransac(picks=picks)
-    assert_raises(ValueError, ransac.fit, epochs)
+    pytest.raises(ValueError, ransac.fit, epochs)
     #
     # should not contain other channel types.
     picks = mne.pick_types(raw.info, meg=False, eeg=True, stim=True,
                            eog=False, exclude=[])
     ransac = Ransac(picks=picks)
-    assert_raises(ValueError, ransac.fit, epochs)
+    pytest.raises(ValueError, ransac.fit, epochs)

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -1,13 +1,13 @@
 # Author: Mainak Jas <mainak.jas@telecom-paristech.fr>
 # License: BSD (3-clause)
 
+import pytest
+
 import mne
 from mne.datasets import sample
 from mne import io
 
 from autoreject import Ransac
-
-from nose.tools import pytest.raises, assert_true
 
 import matplotlib
 matplotlib.use('Agg')
@@ -21,7 +21,6 @@ raw.info['projs'] = list()
 
 def test_ransac():
     """Some basic tests for ransac."""
-
     event_id = {'Visual/Left': 3}
     tmin, tmax = -0.2, 0.5
 

--- a/autoreject/tests/test_utils.py
+++ b/autoreject/tests/test_utils.py
@@ -12,7 +12,7 @@ from autoreject.utils import clean_by_interp, interpolate_bads
 from autoreject.utils import _interpolate_bads_eeg
 import mne.channels.interpolation
 
-from nose.tools import assert_raises
+from nose.tools import pytest.raises
 
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
@@ -40,7 +40,7 @@ def test_utils():
     this_epoch = epochs.copy()
     epochs_clean = clean_by_interp(this_epoch)
     assert_array_equal(this_epoch.get_data(), epochs.get_data())
-    assert_raises(AssertionError, assert_array_equal, epochs_clean.get_data(),
+    pytest.raises(AssertionError, assert_array_equal, epochs_clean.get_data(),
                   this_epoch.get_data())
 
     picks_meg = mne.pick_types(evoked.info, meg='grad', eeg=False, exclude=[])
@@ -55,7 +55,7 @@ def test_utils():
         evoked.interpolate_bads(reset_bads=False)
         assert_array_equal(evoked.data[picks_bad],
                            evoked_autoreject.data[picks_bad])
-        assert_raises(AssertionError, assert_array_equal,
+        pytest.raises(AssertionError, assert_array_equal,
                       evoked_orig.data[picks_bad], evoked.data[picks_bad])
 
     # test that autoreject EEG interpolation code behaves the same as MNE

--- a/autoreject/tests/test_utils.py
+++ b/autoreject/tests/test_utils.py
@@ -2,6 +2,7 @@
 # License: BSD (3-clause)
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
+import pytest
 
 import mne
 from mne.datasets import sample
@@ -11,8 +12,6 @@ from mne import io
 from autoreject.utils import clean_by_interp, interpolate_bads
 from autoreject.utils import _interpolate_bads_eeg
 import mne.channels.interpolation
-
-from nose.tools import pytest.raises
 
 data_path = sample.data_path()
 raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
@@ -27,7 +26,6 @@ evoked = mne.read_evokeds(evoked_fname, condition='Left Auditory',
 
 def test_utils():
     """Test utils."""
-
     event_id = {'Visual/Left': 3}
     tmin, tmax = -0.2, 0.5
     events = mne.find_events(raw)
@@ -69,7 +67,7 @@ def test_utils():
 
 
 def test_interpolate_bads():
-    """Test interpolate bads"""
+    """Test interpolate bads."""
     event_id = None
     events = mne.find_events(raw)
     tmin, tmax = -0.2, 0.5

--- a/autoreject/tests/test_viz.py
+++ b/autoreject/tests/test_viz.py
@@ -9,7 +9,7 @@ from mne import io
 
 import autoreject
 
-from nose.tools import assert_raises
+from nose.tools import pytest.raises
 
 import matplotlib
 matplotlib.use('Agg')
@@ -41,6 +41,6 @@ def test_viz():
     reject_log.plot_epochs(epochs)
     reject_log.plot()
     reject_log.plot(orientation='horizontal')
-    assert_raises(ValueError, reject_log.plot_epochs, epochs[:2])
-    assert_raises(ValueError, reject_log.plot, 'down')
+    pytest.raises(ValueError, reject_log.plot_epochs, epochs[:2])
+    pytest.raises(ValueError, reject_log.plot, 'down')
     plt.close('all')

--- a/autoreject/tests/test_viz.py
+++ b/autoreject/tests/test_viz.py
@@ -2,14 +2,13 @@
 # License: BSD (3-clause)
 
 import numpy as np
+import pytest
 
 import mne
 from mne.datasets import sample
 from mne import io
 
 import autoreject
-
-from nose.tools import pytest.raises
 
 import matplotlib
 matplotlib.use('Agg')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[nosetests]
-verbosity = 2
-detailed-errors = 1
-with-coverage = 1
-cover-package = autoreject
-
 [flake8]
 exclude = __init__.py
 ignore = E241, W504


### PR DESCRIPTION
closes #163 

Dropping the nose module, because it is not actively maintained. Moving to pytest!

using a mixture of:
- nose2pytest
- global search+replace
- manual fiddling

I tried to be as minimal as possible.