### PR TITLE
[ENH] Change to OpenNeuro-py downloader for example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,4 @@ jobs:
                 paths:
                   - ~/.mne
                   - ~/mne_data/MNE-sample-data
-                  - $CIRCLE_WORKING_DIRECTORY/examples/ds117
+                  - $CIRCLE_WORKING_DIRECTORY/examples/ds000117

--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,11 @@ These are the dependencies to use ``autoreject``:
 * ``joblib``
 * ``matplotlib`` (>=1.3)
 
-Two optional dependencies are:
+Optional dependencies are:
 
 * ``tqdm`` (for nice progressbars)
 * ``h5py`` (for IO)
+* ``openneuro-py`` (for fetching data from OpenNeuro.org)
 
 Cite
 ----

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -252,25 +252,6 @@ def _clean_by_interp(inst, picks=None, dots=None, verbose='progressbar'):
     return inst_interp
 
 
-def fetch_file(url, file_name, resume=True, timeout=10.):
-    """Load requested file, downloading it if needed or requested.
-
-    Parameters
-    ----------
-    url: string
-        The url of file to be downloaded.
-    file_name: string
-        Name, along with the path, of where downloaded file will be saved.
-    resume: bool, optional
-        If true, try to resume partially downloaded files.
-    timeout : float
-        The URL open timeout.
-    """
-    from mne.utils import _fetch_file
-    _fetch_file(url=url, file_name=file_name, print_destination=True,
-                resume=resume, hash_=None, timeout=timeout)
-
-
 def interpolate_bads(inst, picks, dots=None, reset_bads=True, mode='accurate'):
     """Interpolate bad MEG and EEG channels."""
     import mne

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -47,5 +47,4 @@ Functions:
 .. autosummary::
    :toctree: generated/
 
-   fetch_file
    set_matplotlib_defaults

--- a/examples/plot_visualize_bad_epochs.py
+++ b/examples/plot_visualize_bad_epochs.py
@@ -15,10 +15,11 @@ visualize the bad sensors in each trial
 
 # %%
 # First, we download the data from OpenfMRI which is hosted on OpenNeuro.
-# We will do this using ``openneuro-py``.
+# We will do this using ``openneuro-py`` which can be installed using pip
+# (``pip install openneuro-py``).
 
 import os
-import openneuro as on
+import openneuro
 import autoreject
 
 dataset = 'ds000117'  # The id code on OpenNeuro for this example dataset
@@ -29,8 +30,8 @@ target_dir = os.path.join(
 if not os.path.isdir(target_dir):
     os.makedirs(target_dir)
 
-on.download(dataset=dataset, target_dir=target_dir,
-            include=[f'sub-{subject_id}/ses-meg/'])
+openneuro.download(dataset=dataset, target_dir=target_dir,
+                   include=[f'sub-{subject_id}/ses-meg/'])
 
 # %%
 # We will create epochs with data starting 200 ms before trigger onset

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
                   'numpydoc',
                   'cython',
                   'pillow',
+                  'openneuro-py'
               ]
           },
           packages=find_packages(),


### PR DESCRIPTION
Addresses https://github.com/mne-tools/mne-python/issues/9078.

Instead of downloading a whole tar file that is stashed somewhere, the idea is to change to using `openneuro-py` to download example data files.