### PR TITLE
[MRG] FIX: don't reset bad channels

### DIFF
--- a/autoreject/tests/test_utils.py
+++ b/autoreject/tests/test_utils.py
@@ -36,7 +36,9 @@ def test_utils():
                         reject=None, preload=True)
 
     this_epoch = epochs.copy()
+    assert this_epoch.info['bads'] == ['MEG 2443']
     epochs_clean = clean_by_interp(this_epoch)
+    assert this_epoch.info['bads'] == ['MEG 2443']
     assert_array_equal(this_epoch.get_data(), epochs.get_data())
     pytest.raises(AssertionError, assert_array_equal, epochs_clean.get_data(),
                   this_epoch.get_data())

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -249,6 +249,7 @@ def _clean_by_interp(inst, picks=None, dots=None, verbose='progressbar'):
         else:
             raise ValueError('Unrecognized type for inst')
         inst._data[:, pick_interp] = data_orig.copy()
+    inst.info['bads'] = inst_interp.info['bads'].copy()
     return inst_interp
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,8 @@ Changelog
 Bug
 ~~~
 
+- Don't reset `epochs.info['bads']` within :func:`autoreject.compute_thresholds` by `Mainak Jas`_ in `#203 <https://github.com/autoreject/autoreject/pull/203>`_
+
 API
 ~~~
 


### PR DESCRIPTION
see https://mne.discourse.group/t/using-autoreject-to-compute-local-threshes-impacts-the-epochs-dropped-using-a-global-threshold/2931

on mailing list