### PR TITLE
[MRG, BUG] fix long computation time in example

### DIFF
--- a/examples/plot_auto_repair.py
+++ b/examples/plot_auto_repair.py
@@ -82,6 +82,8 @@ raw.info['projs'] = list()  # remove proj, don't proj while interpolating
 epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
                     baseline=(None, 0), reject=None,
                     verbose=False, detrend=0, preload=True)
+epochs = epochs.pick_channels(np.array(epochs.ch_names)[np.arange(
+    0, len(epochs.ch_names), 11)])  # decimate to save computation time
 
 # %%
 # :class:`autoreject.AutoReject` internally does cross-validation to

--- a/examples/plot_auto_repair.py
+++ b/examples/plot_auto_repair.py
@@ -51,7 +51,7 @@ from autoreject import (AutoReject, set_matplotlib_defaults)  # noqa
 
 import os.path as op  # noqa
 
-mne.utils.check_random_state(42)
+check_random_state(42)
 
 data_path = sample.data_path()
 sample_dir = op.join(data_path, 'MEG', 'sample')
@@ -138,4 +138,4 @@ plt.tight_layout()
 # To top things up, we can also visualize the bad sensors for each trial using
 # a heatmap.
 
-fig = ar.get_reject_log(epochs['Auditory/Left']).plot('vertical')
+ar.get_reject_log(epochs['Auditory/Left']).plot()


### PR DESCRIPTION
Related to https://github.com/autoreject/autoreject/pull/205

This example takes ~70 minutes to run for some reason. This fixes that by picking a subset of channels but leaving the one that really makes the example.