### PR TITLE
[MRG, BUG] Fix long example execution time (2nd example)

### DIFF
--- a/examples/plot_visualize_bad_epochs.py
+++ b/examples/plot_visualize_bad_epochs.py
@@ -13,7 +13,7 @@ visualize the bad sensors in each trial
 
 # sphinx_gallery_thumbnail_number = 2
 
-###############################################################################
+# %%
 # First, we download the data from OpenfMRI which is hosted on OpenNeuro.
 # We will do this using ``openneuro-py`` which can be installed using pip
 # (``pip install openneuro-py``).
@@ -34,7 +34,7 @@ run_fname = op.join(f'sub-{subject_id}', 'ses-meg', 'meg',
                     '_run-{:02d}_meg.fif'.format(run))
 openneuro.download(dataset=dataset, target_dir=target_dir, include=[run_fname])
 
-###############################################################################
+# %%
 # We will create epochs with data starting 200 ms before trigger onset
 # and continuing up to 800 ms after that. The data contains visual stimuli for
 # famous faces, unfamiliar faces, as well as scrambled faces.
@@ -61,7 +61,7 @@ mne.io.set_eeg_reference(raw)
 epochs = mne.Epochs(raw, events, events_id, tmin, tmax, proj=True,
                     baseline=None, preload=True, reject=None, decim=4)
 
-###############################################################################
+# %%
 # Now, we apply autoreject
 
 from autoreject import AutoReject, compute_thresholds  # noqa
@@ -71,7 +71,7 @@ exclude = []  # XXX
 picks = mne.pick_types(epochs.info, meg=False, eeg=True, stim=False,
                        eog=False, exclude=exclude)
 
-###############################################################################
+# %%
 # Note that :class:`autoreject.AutoReject` by design supports multiple
 # channels. If no picks are passed separate solutions will be computed for each
 # channel type and internally combines. This then readily supports cleaning
@@ -87,7 +87,7 @@ ar = AutoReject(picks=picks, random_state=42, n_jobs=1, verbose='tqdm')
 
 epochs_ar, reject_log = ar.fit_transform(this_epoch, return_log=True)
 
-###############################################################################
+# %%
 # We can visualize the cross validation curve over two variables
 
 import numpy as np  # noqa
@@ -115,7 +115,7 @@ plt.title('Mean cross validation error (x 1e6)')
 plt.colorbar()
 plt.show()
 
-###############################################################################
+# %%
 # ... and visualize the bad epochs and sensors. Bad sensors which have been
 # interpolated are in blue. Bad sensors which are not interpolated are in red.
 # Bad trials are also in red.
@@ -123,17 +123,17 @@ plt.show()
 scalings = dict(eeg=40e-6)
 reject_log.plot_epochs(this_epoch, scalings=scalings)
 
-###############################################################################
+# %%
 # ... and the epochs after cleaning with autoreject
 
 epochs_ar.plot(scalings=scalings)
 
-###############################################################################
+# %%
 # The epochs dropped by autoreject are also stored in epochs.drop_log
 
 epochs_ar.plot_drop_log()
 
-###############################################################################
+# %%
 # Finally, the evoked before and after autoreject, for sanity check. We use
 # the ``spatial_colors`` argument from MNE as it allows us to see that
 # the eyeblinks have not yet been cleaned but the bad channels have been

--- a/examples/plot_visualize_bad_epochs.py
+++ b/examples/plot_visualize_bad_epochs.py
@@ -59,7 +59,7 @@ events = mne.find_events(raw, stim_channel='STI101',
 mne.io.set_eeg_reference(raw)
 
 epochs = mne.Epochs(raw, events, events_id, tmin, tmax, proj=True,
-                    baseline=None, preload=False, reject=None, decim=4)
+                    baseline=None, preload=True, reject=None, decim=4)
 
 ###############################################################################
 # Now, we apply autoreject


### PR DESCRIPTION
Related to #205. Another example took 30 minutes to execute. This gets it down to ~8 minutes with the same content by cutting down the number of downloads and epochs.