### PR TITLE
MNT: Pass info as recently required positional argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         mne-version: [stable, main]
     env:
       TZ: Europe/Berlin

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Dependencies
 
 These are the dependencies to use ``autoreject``:
 
-* ``Python`` (>=3.6)
+* ``Python`` (>=3.7)
 * ``mne`` (>=0.14)
 * ``numpy`` (>=1.8)
 * ``scipy`` (>=0.16)

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -405,7 +405,7 @@ def _compute_dots(info, mode='fast'):
     coils = _create_meg_coils(info['chs'], 'normal', info['dev_head_t'],
                               templates)
     my_origin = _check_origin((0., 0., 0.04), info)
-    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, coils, 'meg')
+    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, info, coils, 'meg')
     self_dots = _do_self_dots(int_rad, False, coils, my_origin, 'meg',
                               lut_fun, n_fact, n_jobs=1)
     cross_dots = _do_cross_dots(int_rad, False, coils, coils,
@@ -441,7 +441,8 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
     coils_from = _create_meg_coils(info_from['chs'], 'normal',
                                    info_from['dev_head_t'], templates)
     my_origin = _check_origin((0., 0., 0.04), info_from)
-    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, coils_from, 'meg')
+    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, info_from, coils_from,
+                                                  'meg')
 
     # This function needs a clean input. It hates the presence of other
     # channels than MEG channels. Make sure all is picked.

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -396,7 +396,6 @@ def _interpolate_bads_meg_fast(inst, picks, mode='accurate',
 
 def _compute_dots(info, mode='fast'):
     """Compute all-to-all dots."""
-    from mne.forward._field_interpolation import _setup_dots
     from mne.forward._lead_dots import _do_self_dots, _do_cross_dots
     from mne.forward._make_forward import _create_meg_coils, _read_coil_defs
     from mne.bem import _check_origin
@@ -405,7 +404,8 @@ def _compute_dots(info, mode='fast'):
     coils = _create_meg_coils(info['chs'], 'normal', info['dev_head_t'],
                               templates)
     my_origin = _check_origin((0., 0., 0.04), info)
-    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, info, coils, 'meg')
+    int_rad, noise, lut_fun, n_fact = _patch_setup_dots(mode, info,
+                                                        coils, 'meg')
     self_dots = _do_self_dots(int_rad, False, coils, my_origin, 'meg',
                               lut_fun, n_fact, n_jobs=1)
     cross_dots = _do_cross_dots(int_rad, False, coils, coils,
@@ -425,7 +425,6 @@ def _pick_dots(dots, pick_from, pick_to):
 def _fast_map_meg_channels(info, pick_from, pick_to,
                            dots=None, mode='fast'):
     from mne.io.pick import pick_info
-    from mne.forward._field_interpolation import _setup_dots
     from mne.forward._field_interpolation import _compute_mapping_matrix
     from mne.forward._make_forward import _create_meg_coils, _read_coil_defs
     from mne.bem import _check_origin
@@ -441,8 +440,8 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
     coils_from = _create_meg_coils(info_from['chs'], 'normal',
                                    info_from['dev_head_t'], templates)
     my_origin = _check_origin((0., 0., 0.04), info_from)
-    int_rad, noise, lut_fun, n_fact = _setup_dots(mode, info_from, coils_from,
-                                                  'meg')
+    int_rad, noise, lut_fun, n_fact = _patch_setup_dots(mode, info_from,
+                                                        coils_from, 'meg')
 
     # This function needs a clean input. It hates the presence of other
     # channels than MEG channels. Make sure all is picked.
@@ -462,3 +461,15 @@ def _fast_map_meg_channels(info, pick_from, pick_to,
     mne.set_log_level(verbose)
 
     return fmd['data']
+
+
+def _patch_setup_dots(mode, info, coils, ch):
+    """
+    Monkey patcher for MNE's _setup_dots (changed parametrization in v0.24).
+    """
+    from mne.forward._field_interpolation import _setup_dots
+    from mne.utils import check_version
+    if not check_version('mne', '0.24'):
+        return _setup_dots(mode, coils, ch)
+    else:
+        return _setup_dots(mode, info, coils, ch)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ Installation
 ============
 
 We recommend the `Anaconda Python distribution <https://www.anaconda.com/>`_
-and a **Python version >=3.6**. To install ``autoreject``, you first need to
+and a **Python version >=3.7**. To install ``autoreject``, you first need to
 install its dependencies::
 
 	$ conda install numpy matplotlib scipy scikit-learn joblib


### PR DESCRIPTION
Here is a start of a PR that ~addresses~ closes #211.
Note that this adjusts to behavior of MNE that will be released with MNE 0.24 if I am not mistaken.

~When I tested this locally, it seems that there are further adjustments needed, because MNE's ``_setup_dots`` does not return ``noise`` as a dictionary anymore, but as an ``mne.cov.Covariance`` object, and on a first, quick glance this seems to break some things.~ EDIT: Nevermind - I passed the wrong ``info`` :) . Thx @jasmainak for catching this!

[edit: removed erroneous tracebacks]

(Happy to look into this further, but need to rush to a meeting now - PRing this now to not delay anyone else)