### PR TITLE
Fix #224 - Allow passing a valid string to picks.

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -615,16 +615,24 @@ class _AutoReject(BaseAutoReject):
         ----------
         epochs : instance of mne.Epochs
             The epochs from which to get the drop logs.
-        picks : np.ndarray, shape(n_channels, ) | list | None
-            The channel indices to be used. If None, the .picks attribute
-            will be used.
+        picks : str | list | slice | None
+            Channels to include. Slices and lists of integers will be
+            interpreted as channel indices. In lists, channel *type* strings
+            (e.g., ``['meg', 'eeg']``) will pick channels of those types,
+            channel *name* strings (e.g., ``['MEG0111', 'MEG2623']`` will pick
+            the given channels. Can also be the string values ``'all'`` to pick
+            all channels, or ``'data'`` to pick data channels. None (default)
+            will use the .picks attribute. Note that channels in
+            ``info['bads']`` *will be included* if their names or indices are
+            explicitly provided.
 
         Returns
         -------
         reject_log : instance of autoreject.RejectLog
             The rejection log.
         """
-        picks = (self.picks_ if picks is None else picks)
+        picks = (self.picks_ if picks is None else
+                 _handle_picks(epochs.info, picks))
         picks_by_type = _get_picks_by_type(picks=picks, info=epochs.info)
         assert len(picks_by_type) == 1
         ch_type, this_picks = picks_by_type[0]

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -471,9 +471,14 @@ class _AutoReject(BaseAutoReject):
     thresh_func : callable | None
         Function which returns the channel-level thresholds. If None,
         defaults to :func:`autoreject.compute_thresholds`.
-    picks : ndarray, shape(n_channels,) | None
-        The channels to be considered for autoreject. If None, defaults
-        to data channels {'meg', 'eeg'}.
+    picks : str | list | slice | None
+        Channels to include. Slices and lists of integers will be interpreted
+        as channel indices. In lists, channel *type* strings (e.g.,
+        ``['meg', 'eeg']``) will pick channels of those types, channel *name*
+        strings (e.g., ``['MEG0111', 'MEG2623']`` will pick the given channels.
+        Can also be the string values ``'all'`` to pick all channels, or
+        ``'data'`` to pick data channels. None (default) will pick data
+        channels {'meg', 'eeg'}. Note that channels in ``info['bads']``
     verbose : 'tqdm', 'tqdm_notebook', 'progressbar' or False
         The verbosity of progress messages.
         If `'progressbar'`, use `mne.utils.ProgressBar`.

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -375,9 +375,15 @@ def compute_thresholds(epochs, method='bayesian_optimization',
         'bayesian_optimization' or 'random_search'
     random_state : int seed, RandomState instance, or None (default)
         The seed of the pseudo random number generator to use
-    picks : ndarray, shape(n_channels,) | None
-        The channels to be considered for autoreject. If None, defaults
-        to data channels {'meg', 'eeg'}.
+    picks : str | list | slice | None
+        Channels to include. Slices and lists of integers will be interpreted
+        as channel indices. In lists, channel *type* strings (e.g.,
+        ``['meg', 'eeg']``) will pick channels of those types, channel *name*
+        strings (e.g., ``['MEG0111', 'MEG2623']`` will pick the given channels.
+        Can also be the string values ``'all'`` to pick all channels, or
+        ``'data'`` to pick data channels. None (default) will pick data
+        channels {'meg', 'eeg'}. Note that channels in ``info['bads']`` *will
+        be included* if their names or indices are explicitly provided.
     augment : boolean
         Whether to augment the data or not. By default it is True, but
         set it to False, if the channel locations are not available.

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -852,11 +852,17 @@ class AutoReject(object):
         This is :math:`\\rho`. If None, defaults to np.array([1, 4, 32])
     cv : a scikit-learn cross-validation object
         Defaults to cv=10
-    picks : ndarray, shape(n_channels) | None
-        The channels to be considered for autoreject. If None, defaults
-        to data channels {'meg', 'eeg'}, which will lead fitting and combining
-        autoreject solutions across these channel types. Note that, if picks is
-        None, autoreject ignores channels marked bad in epochs.info['bads'].
+    picks : str | list | slice | None
+        Channels to include. Slices and lists of integers will be interpreted
+        as channel indices. In lists, channel *type* strings (e.g.,
+        ``['meg', 'eeg']``) will pick channels of those types, channel *name*
+        strings (e.g., ``['MEG0111', 'MEG2623']`` will pick the given channels.
+        Can also be the string values ``'all'`` to pick all channels, or
+        ``'data'`` to pick data channels. None (default) will pick data
+        channels {'meg', 'eeg'}, which will lead fitting and combining
+        autoreject solutions across these channel types. Note that channels in
+        ``info['bads']`` *will be included* if their names or indices are
+        explicitly provided.
     thresh_method : str
         'bayesian_optimization' or 'random_search'
     n_jobs : int

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -947,7 +947,7 @@ class AutoReject(object):
         self : instance of AutoReject
             The instance.
         """
-        self.picks_ = _handle_picks(picks=self.picks, info=epochs.info)
+        self.picks_ = _handle_picks(info=epochs.info, picks=self.picks)
         _check_data(epochs, picks=self.picks_, verbose=self.verbose)
         self.cv_ = self.cv
         if isinstance(self.cv_, int):

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -1050,9 +1050,16 @@ class AutoReject(object):
         ----------
         epochs : instance of mne.Epochs
             The epoched data for which the reject log is computed.
-        picks : np.ndarray, shape(n_channels, ) | list | None
-            The channel indices to be used. If None, the .picks attribute
-            will be used.
+        picks : str | list | slice | None
+            Channels to include. Slices and lists of integers will be
+            interpreted as channel indices. In lists, channel *type* strings
+            (e.g., ``['meg', 'eeg']``) will pick channels of those types,
+            channel *name* strings (e.g., ``['MEG0111', 'MEG2623']`` will pick
+            the given channels. Can also be the string values ``'all'`` to pick
+            all channels, or ``'data'`` to pick data channels. None (default)
+            will use the .picks attribute. Note that channels in
+            ``info['bads']`` *will be included* if their names or indices are
+            explicitly provided.
 
         Returns
         -------

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -904,7 +904,7 @@ class AutoReject(object):
         self.thresh_method = thresh_method
         self.cv = cv
         self.verbose = verbose
-        self.picks = picks  # XXX : should maybe be ch_types?
+        self.picks = picks
         self.n_jobs = n_jobs
         self.random_state = random_state
 

--- a/autoreject/ransac.py
+++ b/autoreject/ransac.py
@@ -80,9 +80,13 @@ class Ransac(object):
             Number of parallel jobs.
         random_state : None | int | np.random.RandomState
             The seed of the pseudo random number generator to use.
-        picks : ndarray, shape(n_channels) | None
-            The channels to be considered for autoreject. If None, defaults
-            to data channels {'meg', 'eeg'}.
+        picks : str | list | slice | None
+            Channels to include. Slices and lists of integers will be
+            interpreted as channel indices. In lists, channel *name* strings
+            (e.g., ``['MEG0111', 'MEG2623']``) will pick the given channels.
+            None (default) will pick data channels {'meg', 'eeg'}. Note that
+            channels in ``info['bads']`` *will be included* if their names or
+            indices are explicitly provided.
         verbose : 'tqdm', 'tqdm_notebook', 'progressbar' or False
             The verbosity of progress messages.
             If `'progressbar'`, use `mne.utils.ProgressBar`.

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -39,7 +39,7 @@ def test_ransac():
     # Pass string instead of array of idx
     picks = 'eeg'
     ransac = Ransac(picks=picks, random_state=np.random.RandomState(42))
-    epochs_clean = ransac.fit_transform(epochs[:2])
+    epochs = ransac.fit(epochs[:2])
     assert len(epochs_clean[:2]) == len(epochs[:2])
     expected = mne.pick_types(epochs.info, meg=False, eeg=True, stim=False,
                               eog=False, exclude='bads')

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -39,7 +39,7 @@ def test_ransac():
     # Pass string instead of array of idx
     picks = 'eeg'
     ransac = Ransac(picks=picks)
-    epochs = ransac.fit(epochs[:2])
+    epochs_clean = ransac.fit(epochs[:2])
     assert len(epochs_clean[:2]) == len(epochs[:2])
     expected = mne.pick_types(epochs.info, meg=False, eeg=True, stim=False,
                               eog=False, exclude='bads')

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -36,16 +36,23 @@ def test_ransac():
     ransac = Ransac(picks=picks, random_state=np.random.RandomState(42))
     epochs_clean = ransac.fit_transform(epochs)
     assert len(epochs_clean) == len(epochs)
+
+    # Pass string instead of array of idx
+    picks = 'eeg'
+    ransac = Ransac(picks=picks, random_state=np.random.RandomState(42))
+    epochs_clean = ransac.fit_transform(epochs)
+    assert len(epochs_clean) == len(epochs)
+
     # Pass numpy instead of epochs
     X = epochs.get_data()
     pytest.raises(AttributeError, ransac.fit, X)
-    #
+
     # should not contain both channel types
     picks = mne.pick_types(epochs.info, meg=True, eeg=False, stim=False,
                            eog=False, exclude=[])
     ransac = Ransac(picks=picks)
     pytest.raises(ValueError, ransac.fit, epochs)
-    #
+
     # should not contain other channel types.
     picks = mne.pick_types(raw.info, meg=False, eeg=True, stim=True,
                            eog=False, exclude=[])

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -38,7 +38,7 @@ def test_ransac():
 
     # Pass string instead of array of idx
     picks = 'eeg'
-    ransac = Ransac(picks=picks, random_state=np.random.RandomState(42))
+    ransac = Ransac(picks=picks)
     epochs = ransac.fit(epochs[:2])
     assert len(epochs_clean[:2]) == len(epochs[:2])
     expected = mne.pick_types(epochs.info, meg=False, eeg=True, stim=False,

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -39,8 +39,7 @@ def test_ransac():
     # Pass string instead of array of idx
     picks = 'eeg'
     ransac = Ransac(picks=picks)
-    epochs_clean = ransac.fit(epochs[:2])
-    assert len(epochs_clean[:2]) == len(epochs[:2])
+    ransac.fit(epochs[:2])
     expected = mne.pick_types(epochs.info, meg=False, eeg=True, stim=False,
                               eog=False, exclude='bads')
     assert (expected == ransac.picks).all()

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -32,7 +32,6 @@ def test_ransac():
     # normal case
     picks = mne.pick_types(epochs.info, meg='mag', eeg=False, stim=False,
                            eog=False, exclude=[])
-
     ransac = Ransac(picks=picks, random_state=np.random.RandomState(42))
     epochs_clean = ransac.fit_transform(epochs)
     assert len(epochs_clean) == len(epochs)
@@ -40,8 +39,11 @@ def test_ransac():
     # Pass string instead of array of idx
     picks = 'eeg'
     ransac = Ransac(picks=picks, random_state=np.random.RandomState(42))
-    epochs_clean = ransac.fit_transform(epochs)
-    assert len(epochs_clean) == len(epochs)
+    epochs_clean = ransac.fit_transform(epochs[:2])
+    assert len(epochs_clean[:2]) == len(epochs[:2])
+    expected = mne.pick_types(epochs.info, meg=False, eeg=True, stim=False,
+                              eog=False, exclude='bads')
+    assert (expected == ransac.picks).all()
 
     # Pass numpy instead of epochs
     X = epochs.get_data()

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -211,9 +211,15 @@ def clean_by_interp(inst, picks=None, verbose='progressbar'):
     ----------
     inst : instance of mne.Evoked or mne.Epochs
         The evoked or epochs object.
-    picks : ndarray, shape(n_channels,) | None
-        The channels to be considered for autoreject. If None, defaults
-        to data channels {'meg', 'eeg'}.
+    picks : str | list | slice | None
+        Channels to include. Slices and lists of integers will be interpreted
+        as channel indices. In lists, channel *type* strings (e.g.,
+        ``['meg', 'eeg']``) will pick channels of those types, channel *name*
+        strings (e.g., ``['MEG0111', 'MEG2623']`` will pick the given channels.
+        Can also be the string values ``'all'`` to pick all channels, or
+        ``'data'`` to pick data channels. None (default) will pick data
+        channels {'meg', 'eeg'}. Note that channels in ``info['bads']`` *will
+        be included* if their names or indices are explicitly provided.
     verbose : 'tqdm', 'tqdm_notebook', 'progressbar' or False
         The verbosity of progress messages.
         If `'progressbar'`, use `mne.utils.ProgressBar`.
@@ -306,8 +312,6 @@ def _interpolate_bads_eeg(inst, picks=None, verbose=None):
 
     bads_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
     goods_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
-
-    inst.info._check_consistency()
     bads_idx[picks] = [inst.ch_names[ch] in inst.info['bads'] for ch in picks]
 
     if len(picks) == 0 or bads_idx.sum() == 0:

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import mne
 from mne import pick_types, pick_info
+from mne.io.pick import _picks_to_idx
 from mne.channels.interpolation import _do_interp_dots
 
 
@@ -74,7 +75,7 @@ def _handle_picks(info, picks):
         out = mne.pick_types(info, meg=True, eeg=True, ref_meg=False,
                              fnirs=True, exclude='bads')
     else:
-        out = picks
+        out = _picks_to_idx(info, picks, exclude='bads')
     return out
 
 

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -298,8 +298,13 @@ def _interpolate_bads_eeg(inst, picks=None, verbose=None):
     ----------
     inst : mne.io.Raw, mne.Epochs or mne.Evoked
         The data to interpolate. Must be preloaded.
-    picks: np.ndarray, shape(n_channels, ) | list | None
-        The channel indices to be used for interpolation.
+    picks : str | list | slice | None
+        Channels to include for interpolation. Slices and lists of integers
+        will be interpreted as channel indices. In lists, channel *name*
+        strings (e.g., ``['EEG 01', 'EEG 02']``) will pick the given channels.
+        None (default) will pick all EEG channels. Note that channels in
+        ``info['bads']`` *will be included* if their names or indices are
+        explicitly provided.
     """
     from mne.bem import _fit_sphere
     from mne.utils import logger, warn
@@ -307,8 +312,11 @@ def _interpolate_bads_eeg(inst, picks=None, verbose=None):
     from mne.channels.interpolation import _make_interpolation_matrix
     import numpy as np
 
+    inst.info._check_consistency()
     if picks is None:
         picks = pick_types(inst.info, meg=False, eeg=True, exclude=[])
+    else:
+        picks = _handle_picks(inst.info, picks)
 
     bads_idx = np.zeros(len(inst.ch_names), dtype=np.bool)
     goods_idx = np.zeros(len(inst.ch_names), dtype=np.bool)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -21,6 +21,7 @@ Changelog
 
 - Enable support for fNIRS data types by `Robert Luke`_ in `#177 <https://github.com/autoreject/autoreject/pull/177>`_
 
+- Add additional type support for argument `picks` by `Mathieu Scheltienne`_ in `#225 <https://github.com/autoreject/autoreject/pull/225>`_
 
 Bug
 ~~~
@@ -73,3 +74,4 @@ API
 .. _Hubert Banville: https://hubertjb.github.io/
 .. _Adina Wagner: https://www.adina-wagner.com/
 .. _Robert Luke: https://github.com/rob-luke/
+.. _Mathieu Scheltienne: https://github.com/mscheltienne


### PR DESCRIPTION
Fixes issue #224.

Use MNE `_picks_to_idx()` function to handle picks. Supports both strings and array of indices.
Added test for a string argument.

Is there a changelog to update? Anything else which I might add?