### PR TITLE
allow verbose to be 'tqdm_notebook' and 'progressbar'

### DIFF
--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -173,24 +173,19 @@ def _pbar(iterable, desc, leave=True, position=None, verbose='progressbar'):
         raise ValueError('verbose must be one of {progressbar,'
                          'tqdm, tqdm_notebook, False}. Got %s' % verbose)
 
-    try:
-        from tqdm import tqdm
-        verbose = 'tqdm'
-    except ImportError:
-        pass
-
     if verbose == 'progressbar':
         from mne.utils import ProgressBar
         pbar = ProgressBar(iterable, mesg=desc)
     # XXX: remove the tqdm option after a few releases of MNE since it
     # natively supported by the MNE progressbar
     elif verbose == 'tqdm':
+        from tqdm import tqdm
         pbar = tqdm(iterable, desc=desc, leave=leave, position=position,
                     dynamic_ncols=True)
     elif verbose == 'tqdm_notebook':
-        from tqdm import tqdm_notebook
-        pbar = tqdm_notebook(iterable, desc=desc, leave=leave,
-                             position=position, dynamic_ncols=True)
+        from tqdm.notebook import tqdm
+        pbar = tqdm(iterable, desc=desc, leave=leave,
+                position=position, dynamic_ncols=True)
     elif verbose is False:
         pbar = iterable
     return pbar


### PR DESCRIPTION
It looks like whatever `verbose` option was chosen is overwritten [here](https://github.com/autoreject/autoreject/blob/c3f5a8186ed15fd7e16a4f44d36a3f22390ee2c4/autoreject/utils.py#L178). I deleted this section so that the user supplied option is chosen.

Also changed `tqdm_notebook` to `tqdm.notebook` because the former is deprecated