### PR TITLE
[DOC] fix argument order between n_interpolate and consensus

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -461,11 +461,11 @@ class _AutoReject(BaseAutoReject):
     ----------
     epochs : instance of mne.Epochs
         The epochs object
+    n_interpolate : int (default 0)
+        Number of channels for which to interpolate. This is :math:`\\rho`.
     consensus : float (0 to 1.0)
         Percentage of channels that must agree as a fraction of
         the total number of channels. This sets :math:`\\kappa/Q`.
-    n_interpolate : int (default 0)
-        Number of channels for which to interpolate. This is :math:`\\rho`.
     thresh_func : callable | None
         Function which returns the channel-level thresholds. If None,
         defaults to :func:`autoreject.compute_thresholds`.
@@ -498,10 +498,8 @@ class _AutoReject(BaseAutoReject):
         and the peak-to-peak thresholds as the values.
     """
 
-    def __init__(self, consensus=0.1,
-                 n_interpolate=0, thresh_func=None,
-                 method='bayesian_optimization',
-                 picks=None, dots=None,
+    def __init__(self, n_interpolate=0, consensus=0.1, thresh_func=None,
+                 picks=None, method='bayesian_optimization',  dots=None,
                  verbose=True):
         """Init it."""
         if thresh_func is None:

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -476,7 +476,9 @@ class _AutoReject(BaseAutoReject):
         ``'data'`` to pick data channels. None (default) will pick data
         channels {'meg', 'eeg'}. Note that channels in ``info['bads']``
     thresh_method : str
-        'bayesian_optimization' or 'random_search'
+        'bayesian_optimization' or 'random_search'.
+    dots : tuple
+        2-length tuple returned by utils._compute_dots.
     verbose : boolean
         The verbosity of progress messages.
         If False, suppress all output messages.

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -475,6 +475,8 @@ class _AutoReject(BaseAutoReject):
         Can also be the string values ``'all'`` to pick all channels, or
         ``'data'`` to pick data channels. None (default) will pick data
         channels {'meg', 'eeg'}. Note that channels in ``info['bads']``
+    thresh_method : str
+        'bayesian_optimization' or 'random_search'
     verbose : boolean
         The verbosity of progress messages.
         If False, suppress all output messages.
@@ -497,7 +499,7 @@ class _AutoReject(BaseAutoReject):
     """
 
     def __init__(self, n_interpolate=0, consensus=0.1, thresh_func=None,
-                 picks=None, method='bayesian_optimization',  dots=None,
+                 picks=None, thresh_method='bayesian_optimization',  dots=None,
                  verbose=True):
         """Init it."""
         if thresh_func is None:

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -474,7 +474,8 @@ class _AutoReject(BaseAutoReject):
         strings (e.g., ``['MEG0111', 'MEG2623']`` will pick the given channels.
         Can also be the string values ``'all'`` to pick all channels, or
         ``'data'`` to pick data channels. None (default) will pick data
-        channels {'meg', 'eeg'}. Note that channels in ``info['bads']``
+        channels {'meg', 'eeg'}. Note that channels in ``info['bads']`` *will
+        be included* if their names or indices are explicitly provided.
     thresh_method : str
         'bayesian_optimization' or 'random_search'.
     dots : tuple

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -459,8 +459,6 @@ class _AutoReject(BaseAutoReject):
 
     Parameters
     ----------
-    epochs : instance of mne.Epochs
-        The epochs object
     n_interpolate : int (default 0)
         Number of channels for which to interpolate. This is :math:`\\rho`.
     consensus : float (0 to 1.0)

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -50,7 +50,7 @@ def validation_curve(epochs, y=None, param_name="thresh", param_range=None,
     ----------
     epochs : instance of mne.Epochs.
         The epochs.
-    y : array | None
+    y : array | None
         The labels.
     param_name : str
         Name of the parameter that will be varied.
@@ -838,13 +838,13 @@ class AutoReject(object):
 
     Parameters
     ----------
+    n_interpolate : array | None
+        The values to try for the number of channels for which to interpolate.
+        This is :math:`\\rho`. If None, defaults to np.array([1, 4, 32])
     consensus : array | None
         The values to try for percentage of channels that must agree as a
         fraction of the total number of channels. This sets :math:`\\kappa/Q`.
         If None, defaults to `np.linspace(0, 1.0, 11)`
-    n_interpolate : array | None
-        The values to try for the number of channels for which to interpolate.
-        This is :math:`\\rho`. If None, defaults to np.array([1, 4, 32])
     cv : a scikit-learn cross-validation object
         Defaults to cv=10
     picks : str | list | slice | None

--- a/examples/plot_autoreject_workflow.py
+++ b/examples/plot_autoreject_workflow.py
@@ -47,7 +47,7 @@ openneuro.download(dataset=dataset, target_dir=target_dir,
 # %%
 # We will now load in the raw data from the bdf file downloaded from OpenNeuro
 # and, since this is resting-state data without any events, make regularly
-# spaced events with which to epoch the raw data. In the averaged plot, 
+# spaced events with which to epoch the raw data. In the averaged plot,
 # we can see that there may be some eyeblink
 # artifact contamination but, overall, the data is typical of
 # resting-state EEG.
@@ -91,7 +91,7 @@ reject_log.plot('horizontal')
 
 # %%
 # Autoreject with high-pass filter
-# -------------------------------
+# --------------------------------
 # The data may be very valuable and the time for the experiment
 # limited and so we may want to take steps to reduce the number of
 # epochs dropped by first using other steps to preprocess the data.


### PR DESCRIPTION
While giving a shot to the `AutoReject` class, I got confused by the docstring not matching the actual arguments. 

I changed the docstring to match the argument order.

TODO:
- [x] Fix argument order/docstring for public `AutoReject` class. [Fixed]
- [x] Argument `thresh_func=None` is not documented in the dosctring. What is it? [Unused]
- [x] Public `AutoReject` class argument order is `n_interpolate=None, consensus=None` while private `_AutoReject` class argument order is `consensus=0.1, n_interpolate=0`. Do you want to do something about this? [Fixed]