### PR TITLE
CI: remove unnecessary/problematic sanity check

### DIFF
--- a/.github/workflows/circle-artifacts.yml
+++ b/.github/workflows/circle-artifacts.yml
@@ -5,13 +5,9 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
-        id: step1
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/html/index.html
           circleci-jobs: build
           job-title: Check the rendered docs here!
-      - name: Check the URL
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
I recently introduced this because I thought it was neat, but it lead to problems elsewhere (see https://github.com/bids-standard/bids-specification/pull/944) and I think we should remove it again.