### PR TITLE
doc: use sphinx-gihub-role package

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ extensions = [
     'sphinx_gallery.gen_gallery',
     'numpydoc',
     'sphinx_copybutton',
-    'sphinx-github-role',
+    'sphinx_github_role',
 ]
 
 # configure sphinx-github-role

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,7 @@ extensions = [
     'sphinx_gallery.gen_gallery',
     'numpydoc',
     'sphinx_copybutton',
+    'sphinx-github-role',
 ]
 
 # configure sphinx-github-role

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,6 +29,9 @@ extensions = [
     'sphinx_copybutton',
 ]
 
+# configure sphinx-github-role
+github_default_org_project = ("autoreject", "autoreject")
+
 # configure sphinx-copybutton
 copybutton_prompt_text = r">>> |\.\.\. |\$ "
 copybutton_prompt_is_regexp = True

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,22 +15,22 @@ Current
 Changelog
 ~~~~~~~~~
 
-- Make plotting of reject log more flexible by allowing to change the orientation of plot, option to supress the immediate display of the plot and returning the plot figure for further modification or saving in :meth:`autoreject.RejectLog.plot`, by `Marcin Koculak`_ in `#152 <https://github.com/autoreject/autoreject/pull/152>`_
+- Make plotting of reject log more flexible by allowing to change the orientation of plot, option to supress the immediate display of the plot and returning the plot figure for further modification or saving in :meth:`autoreject.RejectLog.plot`, by `Marcin Koculak`_ in :github:`#152`
 
-- Add `show_names` option to :func:`autoreject.RejectLog.plot` by `Mainak Jas`_ in `#322 <https://github.com/autoreject/autoreject/pull/322>`_
+- Add `show_names` option to :func:`autoreject.RejectLog.plot` by `Mainak Jas`_ in :github:`#322`
 
-- Enable support for fNIRS data types by `Robert Luke`_ in `#177 <https://github.com/autoreject/autoreject/pull/177>`_
+- Enable support for fNIRS data types by `Robert Luke`_ in :github:`#177`
 
-- Add additional type support for argument `picks` by `Mathieu Scheltienne`_ in `#225 <https://github.com/autoreject/autoreject/pull/225>`_
+- Add additional type support for argument `picks` by `Mathieu Scheltienne`_ in :github:`#225`
 
-- Use MNE progressbar by `Patrick Stetz`_ in `#227 <https://github.com/autoreject/autoreject/pull/227>`_
+- Use MNE progressbar by `Patrick Stetz`_ in :github:`#227`
 
 Bug
 ~~~
 
-- Don't reset `epochs.info['bads']` within :func:`autoreject.compute_thresholds` by `Mainak Jas`_ in `#203 <https://github.com/autoreject/autoreject/pull/203>`_
+- Don't reset `epochs.info['bads']` within :func:`autoreject.compute_thresholds` by `Mainak Jas`_ in :github:`#203`
 
-- Adjust usage of a private MNE method used for interpolation that failed for newer MNE versions, by `Adina Wagner`_ in `#212 <https://github.com/autoreject/autoreject/pull/212>`_.
+- Adjust usage of a private MNE method used for interpolation that failed for newer MNE versions, by `Adina Wagner`_ in :github:`#212`.
 
 API
 ~~~
@@ -44,30 +44,30 @@ Changelog
 ~~~~~~~~~
 
 - Introduced a new method :meth:`autoreject.AutoReject.save` and function :func:`autoreject.read_auto_reject`
-  for IO of autoreject objects, by `Mainak Jas`_ in `#120 <https://github.com/autoreject/autoreject/pull/120>`_
+  for IO of autoreject objects, by `Mainak Jas`_ in :github:`#120`
 
 - Make MEG interpolation faster by precomputing dot products for the interpolation, by `Mainak Jas`_
-  in `#122 <https://github.com/autoreject/autoreject/pull/122>`_
+  in :github:`#122`
 
 - Add default option for `param_range` in :func:`autoreject.validation_curve`, by `Alex Gramfort`_
-  in `#129 <https://github.com/autoreject/autoreject/pull/129>`_
+  in :github:`#129`
 
 Bug
 ~~~
 
 - Fixed bug in picking bad channels during interpolation. This bug only affects users who got an assertion
-  error when running :class:`autoreject.Autoreject`. Fixed by `Mainak Jas`_ in `#115 <https://github.com/autoreject/autoreject/pull/115>`_
+  error when running :class:`autoreject.Autoreject`. Fixed by `Mainak Jas`_ in :github:`#115`
 - Added check for channel locations so that autoreject does not
-  hang when the channel positions are nan. Fixed by `Mainak Jas`_ in `#130 <https://github.com/autoreject/autoreject/pull/130>`_
-- Fixed bug in random seed for the Ransac algorithm when n_jobs > 1, by `Legrand Nico`_ and `Mainak Jas`_ in `#138 <https://github.com/autoreject/autoreject/pull/138>`_
-- Fixed pikcling of :class:`autoreject.AutoReject`. Fixed by `Hubert Banville`_ in `#193 <https://github.com/autoreject/autoreject/pull/193>`_
+  hang when the channel positions are nan. Fixed by `Mainak Jas`_ in :github:`#130`
+- Fixed bug in random seed for the Ransac algorithm when n_jobs > 1, by `Legrand Nico`_ and `Mainak Jas`_ in :github:`#138`
+- Fixed pikcling of :class:`autoreject.AutoReject`. Fixed by `Hubert Banville`_ in :github:`#193`
 
 
 API
 ~~~
 
 - Added `ch_types` argument to :func:`autoreject.get_rejection_threshold` to find
-  rejection thresholds for only subset of channel types in the data, by `Mainak Jas`_ in `#140 <https://github.com/autoreject/autoreject/pull/140>`_
+  rejection thresholds for only subset of channel types in the data, by `Mainak Jas`_ in :github:`#140`
 
 .. _Mainak Jas: https://perso.telecom-paristech.fr/mjas/
 .. _Legrand Nico: https://legrandnico.github.io/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,9 +15,11 @@ Current
 Changelog
 ~~~~~~~~~
 
-- Make plotting of reject log more flexible by allowing to change the orientation of plot, option to supress the immediate display of the plot and returning the plot figure for further modification or saving in :meth:`autoreject.RejectLog.plot`, by `Marcin Koculak`_ in :github:`#152`
+- Make plotting of reject log more flexible by allowing to change the orientation of plot,
+  option to supress the immediate display of the plot and returning the plot figure for further
+  modification or saving in :meth:`autoreject.RejectLog.plot`, by `Marcin Koculak`_ in :github:`#152`
 
-- Add `show_names` option to :func:`autoreject.RejectLog.plot` by `Mainak Jas`_ in :github:`#322`
+- Add `show_names` option to :func:`autoreject.RejectLog.plot` by `Mainak Jas`_ in :github:`#209`
 
 - Enable support for fNIRS data types by `Robert Luke`_ in :github:`#177`
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
                   'sphinx-gallery',
                   'sphinx_bootstrap_theme',
                   'sphinx-copybutton',
+                  'sphinx-github-role',
                   'numpydoc',
                   'cython',
                   'pillow',


### PR DESCRIPTION
I think this would be a neat addition, similar to [gh_substitutions.py](https://github.com/mne-tools/mne-bids/blob/4c0755c6eb567c7840d70acf06f22201c5e75c65/doc/sphinxext/gh_substitutions.py#L1) in mne-bids, but without having to add an extra file.

Changelog was updated using regexps in VSCode search&replace:

- find:
```
`#(\d+) <https://github.com/autoreject/autoreject/pull/\d+>`_
```
- replace:
```
:github:`#$1`
```