### PR TITLE
Ci/docs/deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ jobs:
                     cd ~/project/doc
                     make html
                 no_output_timeout: 2h
+
+            - persist_to_workspace:
+                root: ./doc/_build
+                paths: html
+
             - store_artifacts:
                 path: ./doc/_build/html/
                 destination: html
@@ -52,7 +57,7 @@ jobs:
     docs-deploy:
         # will only be run on master branch
         docker:
-          - image: node:8.10.0
+          - image: cimg/node:lts
         steps:
           - checkout
 
@@ -61,8 +66,10 @@ jobs:
 
           - run:
               name: Install and configure dependencies
+              # do not update gh-pages above 3.0.0
+              # see: https://github.com/tschaub/gh-pages/issues/354
               command: |
-                npm install -g --silent gh-pages@2.2
+                npm install -g --silent gh-pages@3.0.0
                 git config --global user.email "circle@autoreject.com"
                 git config --global user.name "Circle Ci"
           - add_ssh_keys:
@@ -80,6 +87,12 @@ workflows:
   commit:
     jobs:
       - build
+      - docs-deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
 
   weekly:
     jobs:

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ This is a library to automatically reject bad trials and repair bad sensors in m
 
 The documentation can be found under the following links:
 
-- for the `stable release <https://autoreject.github.io/>`_
-- for the `latest (development) version <https://circleci.com/api/v1.1/project/github/autoreject/autoreject/latest/artifacts/0/html/index.html?branch=master>`_
+- for the `stable release <https://autoreject.github.io/stable/index.html>`_
+- for the `latest (development) version <https://autoreject.github.io/dev/index.html>`_
 
 .. docs_readme_include_label
 


### PR DESCRIPTION
follow up #253 

`persist_to_workspace` was missing, and the `docs-deploy` job must be listed in `workflows`. I also updated the gh-pages npm package, and the npm version to use LTS.

Otherwise, this seems to work, when looking at the CircleCI produced artifact: https://circleci.com/api/v1.1/project/github/autoreject/autoreject/latest/artifacts/0/html/index.html?branch=master

Once this PR is merged, also the "dev version" (non-CircleCI) should work ... that is, the gh-pages npm package should create a `dev` dir on https://github.com/autoreject/autoreject.github.io.