### PR TITLE
add python publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,34 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade setuptools wheel twine
+    # PYPI_PASSWORD is an upload token restricted to autoreject
+    # PYPI_USERNAME is __token__, if a token is being used
+    # See GitHub settings for autoreject, needs admin rights
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
Still need to set `PYPI_USERNAME ` and `PYPI_PASSWORD` (it's an upload token, not a password), but for that I need more repo rights than I currently have.

To do:
- [ ] update [Wiki how to make a release](https://github.com/autoreject/autoreject/wiki/How-to-make-a-release), once this is merged