### PR TITLE
[MRG] DOC: show methods in API docs

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -1272,7 +1272,7 @@ class RejectLog(object):
 
         Parameters
         ----------
-        orientation : 'vertical' or 'horizontal'
+        orientation : 'vertical' | 'horizontal'
             If `'vertical'` (default), will plot sensors on x-axis and epochs
             on y-axis. If `'horizontal'`, will plot epochs on x-axis and
             sensors on y-axis.
@@ -1288,7 +1288,7 @@ class RejectLog(object):
 
         Returns
         -------
-        figure : Instance of matplotlib.figure.Figure
+        figure : matplotlib.figure.Figure
             The figure object containing the plot.
         """
         import matplotlib as mpl
@@ -1382,7 +1382,7 @@ class RejectLog(object):
 
         Returns
         -------
-        fig : Instance of matplotlib.figure.Figure
+        fig : matplotlib.figure.Figure
             Epochs traces.
         """
         labels = self.labels

--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -52,7 +52,7 @@ def validation_curve(epochs, y=None, param_name="thresh", param_range=None,
 
     Parameters
     ----------
-    epochs : instance of mne.Epochs.
+    epochs : instance of mne.Epochs
         The epochs.
     y : array | None
         The labels.
@@ -63,8 +63,9 @@ def validation_curve(epochs, y=None, param_name="thresh", param_range=None,
         The values of the parameter that will be evaluated.
         If None, 15 values between the min and the max threshold
         will be tested.
-    cv : int, cross-validation generator or an iterable, optional
+    cv : int | sklearn.model_selection object | iterable | None
         Determines the cross-validation strategy.
+        Defaults to None.
     return_param_range : bool
         If True the used param_range is returned.
         Defaults to False.
@@ -199,19 +200,20 @@ def get_rejection_threshold(epochs, decim=1, random_state=None,
 
     Parameters
     ----------
-    epochs : mne.Epochs object
+    epochs : mne.Epochs
         The epochs from which to estimate the epochs dictionary
     decim : int
         The decimation factor: Increment for selecting every nth time slice.
-    random_state : int seed, RandomState instance, or None (default)
+    random_state : int | np.random.RandomState | None
         The seed of the pseudo random number generator to use.
+        Defaults to None.
     ch_types : str | list of str | None
         The channel types for which to find the rejection dictionary.
         e.g., ['mag', 'grad']. If None, the rejection dictionary
         will have keys ['mag', 'grad', 'eeg', 'eog', 'hbo', 'hbr'].
-    cv : a scikit-learn cross-validation object
-        Defaults to cv=5
-    verbose : boolean
+    cv : int | sklearn.model_selection object
+        Defaults to cv=5.
+    verbose : bool
         The verbosity of progress messages.
         If False, suppress all output messages.
 
@@ -331,10 +333,11 @@ def _compute_thresh(this_data, method='bayesian_optimization',
         Data for one channel.
     method : str
         'bayesian_optimization' or 'random_search'
-    cv : iterator
+    cv : int | iterator
         Iterator for cross-validation.
-    random_state : int seed, RandomState instance, or None (default)
+    random_state : int | np.random.RandomState | None
         The seed of the pseudo random number generator to use.
+        Defaults to None.
 
     Returns
     -------
@@ -397,8 +400,9 @@ def compute_thresholds(epochs, method='bayesian_optimization',
         The epochs objects whose thresholds must be computed.
     method : str
         'bayesian_optimization' or 'random_search'
-    random_state : int seed, RandomState instance, or None (default)
-        The seed of the pseudo random number generator to use
+    random_state : int | np.random.RandomState | None
+        The seed of the pseudo random number generator to use.
+        Defaults to None.
     picks : str | list | slice | None
         Channels to include. Slices and lists of integers will be interpreted
         as channel indices. In lists, channel *type* strings (e.g.,
@@ -408,10 +412,10 @@ def compute_thresholds(epochs, method='bayesian_optimization',
         ``'data'`` to pick data channels. None (default) will pick data
         channels {'meg', 'eeg'}. Note that channels in ``info['bads']`` *will
         be included* if their names or indices are explicitly provided.
-    augment : boolean
+    augment : bool
         Whether to augment the data or not. By default it is True, but
         set it to False, if the channel locations are not available.
-    verbose : boolean
+    verbose : bool
         The verbosity of progress messages.
         If False, suppress all output messages.
     n_jobs : int
@@ -503,7 +507,7 @@ class _AutoReject(BaseAutoReject):
         'bayesian_optimization' or 'random_search'.
     dots : tuple
         2-length tuple returned by utils._compute_dots.
-    verbose : boolean
+    verbose : bool
         The verbosity of progress messages.
         If False, suppress all output messages.
 
@@ -869,8 +873,8 @@ class AutoReject(object):
         The values to try for percentage of channels that must agree as a
         fraction of the total number of channels. This sets :math:`\\kappa/Q`.
         If None, defaults to `np.linspace(0, 1.0, 11)`
-    cv : a scikit-learn cross-validation object
-        Defaults to cv=10
+    cv : int | sklearn.model_selection object
+        Defaults to cv=10.
     picks : str | list | slice | None
         Channels to include. Slices and lists of integers will be interpreted
         as channel indices. In lists, channel *type* strings (e.g.,
@@ -886,9 +890,10 @@ class AutoReject(object):
         'bayesian_optimization' or 'random_search'
     n_jobs : int
         The number of jobs.
-    random_state : int seed, RandomState instance, or None (default)
+    random_state : int | np.random.RandomState | None
         The seed of the pseudo random number generator to use.
-    verbose : boolean
+        Defaults to None.
+    verbose : bool
         The verbosity of progress messages.
         If False, suppress all output messages.
 

--- a/autoreject/ransac.py
+++ b/autoreject/ransac.py
@@ -78,8 +78,9 @@ class Ransac(object):
             predictability.
         n_jobs : int
             Number of parallel jobs.
-        random_state : None | int | np.random.RandomState
+        random_state : int | np.random.RandomState | None
             The seed of the pseudo random number generator to use.
+            Defaults to 435656.
         picks : str | list | slice | None
             Channels to include. Slices and lists of integers will be
             interpreted as channel indices. In lists, channel *name* strings
@@ -87,7 +88,7 @@ class Ransac(object):
             None (default) will pick data channels {'meg', 'eeg'}. Note that
             channels in ``info['bads']`` *will be included* if their names or
             indices are explicitly provided.
-        verbose : boolean
+        verbose : bool
             The verbosity of progress messages.
             If False, suppress all output messages.
 

--- a/autoreject/ransac.py
+++ b/autoreject/ransac.py
@@ -57,54 +57,56 @@ def _get_channel_type(epochs, picks):
 
 
 class Ransac(object):
-    """RANSAC algorithm to find bad sensors and repair them."""
+    """RANSAC algorithm to find bad sensors and repair them.
+
+    Implements RAndom SAmple Consensus (RANSAC) method to detect bad sensors.
+
+    Parameters
+    ----------
+    n_resample : int
+        Number of times the sensors are resampled.
+    min_channels : float
+        Fraction of sensors for robust reconstruction.
+    min_corr : float
+        Cut-off correlation for abnormal wrt neighbours.
+    unbroken_time : float
+        Cut-off fraction of time sensor can have poor RANSAC
+        predictability.
+    n_jobs : int
+        Number of parallel jobs.
+    random_state : int | np.random.RandomState | None
+        The seed of the pseudo random number generator to use.
+        Defaults to 435656.
+    picks : str | list | slice | None
+        Channels to include. Slices and lists of integers will be
+        interpreted as channel indices. In lists, channel *name* strings
+        (e.g., ``['MEG0111', 'MEG2623']``) will pick the given channels.
+        None (default) will pick data channels {'meg', 'eeg'}. Note that
+        channels in ``info['bads']`` *will be included* if their names or
+        indices are explicitly provided.
+    verbose : bool
+        The verbosity of progress messages.
+        If False, suppress all output messages.
+
+    Notes
+    -----
+    The window_size is automatically set to the epoch length.
+
+    References
+    ----------
+    [1] Bigdely-Shamlo, Nima, et al.
+        "The PREP pipeline: standardized preprocessing for large-scale EEG
+        analysis." Frontiers in neuroinformatics 9 (2015).
+    [2] Mainak Jas, Denis Engemann, Yousra Bekhti, Federico Raimondo, and
+        Alexandre Gramfort, "Autoreject: Automated artifact rejection for
+        MEG and EEG." arXiv preprint arXiv:1612.08194, 2016.
+    """
 
     def __init__(self, n_resample=50, min_channels=0.25, min_corr=0.75,
                  unbroken_time=0.4, n_jobs=1,
                  random_state=435656, picks=None,
                  verbose=True):
-        """Implements RAndom SAmple Consensus (RANSAC) method to detect bad sensors.
-
-        Parameters
-        ----------
-        n_resample : int
-            Number of times the sensors are resampled.
-        min_channels : float
-            Fraction of sensors for robust reconstruction.
-        min_corr : float
-            Cut-off correlation for abnormal wrt neighbours.
-        unbroken_time : float
-            Cut-off fraction of time sensor can have poor RANSAC
-            predictability.
-        n_jobs : int
-            Number of parallel jobs.
-        random_state : int | np.random.RandomState | None
-            The seed of the pseudo random number generator to use.
-            Defaults to 435656.
-        picks : str | list | slice | None
-            Channels to include. Slices and lists of integers will be
-            interpreted as channel indices. In lists, channel *name* strings
-            (e.g., ``['MEG0111', 'MEG2623']``) will pick the given channels.
-            None (default) will pick data channels {'meg', 'eeg'}. Note that
-            channels in ``info['bads']`` *will be included* if their names or
-            indices are explicitly provided.
-        verbose : bool
-            The verbosity of progress messages.
-            If False, suppress all output messages.
-
-        Notes
-        -----
-        The window_size is automatically set to the epoch length.
-
-        References
-        ----------
-        [1] Bigdely-Shamlo, Nima, et al.
-            "The PREP pipeline: standardized preprocessing for large-scale EEG
-            analysis." Frontiers in neuroinformatics 9 (2015).
-        [2] Mainak Jas, Denis Engemann, Yousra Bekhti, Federico Raimondo, and
-            Alexandre Gramfort, "Autoreject: Automated artifact rejection for
-            MEG and EEG." arXiv preprint arXiv:1612.08194, 2016.
-        """
+        """Initialize Ransac object."""
         self.n_resample = n_resample
         self.min_channels = min_channels
         self.min_corr = min_corr

--- a/autoreject/utils.py
+++ b/autoreject/utils.py
@@ -195,7 +195,7 @@ def clean_by_interp(inst, picks=None, verbose=True):
 
     Parameters
     ----------
-    inst : instance of mne.Evoked or mne.Epochs
+    inst : mne.Evoked | mne.Epochs
         The evoked or epochs object.
     picks : str | list | slice | None
         Channels to include. Slices and lists of integers will be interpreted
@@ -206,7 +206,7 @@ def clean_by_interp(inst, picks=None, verbose=True):
         ``'data'`` to pick data channels. None (default) will pick data
         channels {'meg', 'eeg'}. Note that channels in ``info['bads']`` *will
         be included* if their names or indices are explicitly provided.
-    verbose : boolean
+    verbose : bool
         The verbosity of progress messages.
         If False, suppress all output messages.
 

--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -1,0 +1,12 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__neg__,__hash__
+   :members:
+
+.. _sphx_glr_backreferences_{{ fullname }}:
+
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/doc/_templates/autosummary/function.rst
+++ b/doc/_templates/autosummary/function.rst
@@ -1,0 +1,10 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}
+
+.. _sphx_glr_backreferences_{{ fullname }}:
+
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,6 +47,7 @@ numpydoc_xref_ignore = {
     "instance",
     "of",
     "shape",
+    "object",
 }
 
 autodoc_default_options = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,6 +42,18 @@ autosummary_generate = True  # generate autosummary even if no references
 # configure numpydoc
 numpydoc_xref_param_type = True
 numpydoc_show_class_members = False  # noqa:E501  https://stackoverflow.com/a/34604043/5201771
+numpydoc_xref_ignore = {
+    # words
+    "instance",
+    "of",
+    "shape",
+}
+
+autodoc_default_options = {
+    "members": True,
+    "inherited-members": True,
+    "show-inheritance": True,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -106,6 +118,7 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/devdocs', None),
     'scipy': ('https://scipy.github.io/devdocs', None),
     'matplotlib': ('https://matplotlib.org', None),
+    'sklearn': ('https://scikit-learn.org/stable', None),
 }
 intersphinx_timeout = 5
 


### PR DESCRIPTION
Apart from `__init__`, one cannot inspect methods for AutoReject in the docs: https://autoreject.github.io/dev/generated/autoreject.AutoReject.html#autoreject.AutoReject

trying to fix that here.