### PR TITLE
Fix and refactor RANSAC for n_jobs>1

### DIFF
--- a/autoreject/ransac.py
+++ b/autoreject/ransac.py
@@ -16,44 +16,8 @@ from mne.parallel import check_n_jobs
 from mne.utils import check_random_state
 
 from .utils import _pbar, _handle_picks
-from .utils import _check_data
+from .utils import _check_data, _get_channel_type
 
-
-def _iterate_epochs(ransac, epochs, idxs, ch_subset, verbose):
-    ransac.mappings_ = ransac._get_mappings(epochs, ch_subset)
-    n_channels = len(ransac.picks)
-    corrs = np.zeros((len(idxs), n_channels))
-    for idx, _ in enumerate(_pbar(idxs, desc='Iterating epochs',
-                                  verbose=verbose)):
-        ransac.corr_ = ransac._compute_correlations(
-            epochs.get_data()[idx, ransac.picks])
-        corrs[idx, :] = ransac.corr_
-    return corrs
-
-
-def _get_channel_type(epochs, picks):
-    picked_info = mne.io.pick.pick_info(epochs.info, picks)
-    ch_types_picked = {
-        mne.io.meas_info.channel_type(picked_info, idx)
-        for idx in range(len(picks))}
-    invalid_ch_types_present = [key for key in ch_types_picked
-                                if key not in ['mag', 'grad', 'eeg'] and
-                                key in epochs]
-    if len(invalid_ch_types_present) > 0:
-        raise ValueError('Invalid channel types present in epochs.'
-                         ' Expected ONLY `meg` or ONLY `eeg`. Got %s'
-                         % ', '.join(invalid_ch_types_present))
-
-    has_meg = any(kk in ch_types_picked for kk in ('mag', 'grad'))
-    if 'eeg' in ch_types_picked and has_meg:
-        raise ValueError('Got mixed channel types. Pick either eeg or meg'
-                         ' but not both')
-    if 'eeg' in ch_types_picked:
-        return 'eeg'
-    elif has_meg:
-        return 'meg'
-    else:
-        raise ValueError('Oh no! Your channel type is not known.')
 
 
 class Ransac(object):
@@ -115,28 +79,42 @@ class Ransac(object):
         self.random_state = random_state
         self.verbose = verbose
         self.picks = picks
+        
 
-    def _get_random_subsets(self, info, random_state):
+    def _iterate_epochs(self, epochs, idxs):
+        n_channels = len(self.picks)
+        corrs = np.zeros((len(idxs), n_channels))
+        for i, idx in enumerate(_pbar(idxs, desc='Iterating epochs',
+                                      verbose=self.verbose)):
+            data = epochs.get_data()[idx, self.picks]
+            corrs[i, :] = self._compute_correlations(data)
+        return corrs
+    
+    def _get_random_subsets(self, info):
         """ Get random channels"""
-        # have to set the seed here
-        rng = check_random_state(random_state)
+        # have to set the seed here, as here the only part with randomization
+        # occurs. However, all subsets are precomputed outside of Parallel,
+        # therefore, we can simply compute them once
+        rng = check_random_state(self.random_state)
         picked_info = mne.io.pick.pick_info(info, self.picks)
         n_channels = len(picked_info['ch_names'])
 
         # number of channels to interpolate from
         n_samples = int(np.round(self.min_channels * n_channels))
 
-        # get picks for resamples
-        picks = []
-        for idx in range(self.n_resample):
-            pick = rng.permutation(n_channels)[:n_samples].copy()
-            picks.append(pick)
-
-        # get channel subsets as lists
+        # get picks for resamples, but ignore channels marked as bad
+        bad_chs = info['bads']
+        ch_list = [ch for ch in picked_info['ch_names'] if not ch in bad_chs]
+        assert len(ch_list)>=n_samples, 'too many channels marked as bad,'\
+            'cannot perform interpolation with min_channels={self.min_channels}'
+            
+        # randomly sample subsets of good channels     
         ch_subsets = []
-        for pick in picks:
-            ch_subsets.append([picked_info['ch_names'][p] for p in pick])
-
+        for idx in range(self.n_resample):
+            picks = rng.choice(ch_list, size=n_samples, replace=False)
+            picks = [str(p) for p in picks] # convert from str-array to string
+            ch_subsets.append(picks)
+            
         return ch_subsets
 
     def _get_mappings(self, inst, ch_subsets):
@@ -149,11 +127,12 @@ class Ransac(object):
         pick_to = range(n_channels)
         mappings = []
         # Try different channel subsets
-        for idx in range(len(ch_subsets)):
+        for subset in _pbar(ch_subsets, desc='interpolating channels',
+                            verbose=self.verbose):
             # don't do the following as it will sort the channels!
             # pick_from = pick_channels(ch_names, ch_subsets[idx])
             pick_from = np.array([ch_names.index(name)
-                                  for name in ch_subsets[idx]])
+                                  for name in subset])
             mapping = np.zeros((n_channels, n_channels))
             if self.ch_type == 'meg':
                 mapping[:, pick_from] = _fast_map_meg_channels(
@@ -194,21 +173,32 @@ class Ransac(object):
         n_epochs = len(epochs)
 
         n_jobs = check_n_jobs(self.n_jobs)
-        parallel = Parallel(n_jobs, verbose=10)
-        my_iterator = delayed(_iterate_epochs)
-        if self.verbose is not False and self.n_jobs > 1:
-            print('Iterating epochs ...')
-        verbose = False if self.n_jobs > 1 else self.verbose
-        rng = check_random_state(self.random_state)
-        base_random_state = rng.randint(np.iinfo(np.int16).max)
-        self.ch_subsets_ = [self._get_random_subsets(
-                            epochs.info, base_random_state + random_state)
-                            for random_state in np.arange(0, n_epochs, n_jobs)]
-        epoch_idxs = np.array_split(np.arange(n_epochs), n_jobs)
-        corrs = parallel(my_iterator(self, epochs, idxs, chs, verbose)
-                         for idxs, chs in zip(epoch_idxs, self.ch_subsets_))
+        parallel = Parallel(n_jobs, verbose=10 if self.verbose else 0)
+
+        # create `n_resample` different random subsamples of channels,
+        # with each subsample set containing `min_channels` amount of 
+        # random channels from the list of all channels.
+        ch_subsets = self._get_random_subsets(epochs.info)
+        
+        # compute mappings with possibility of parallelization
+        n_splits = min(n_jobs, self.n_resample) #max n_resample splits possible
+        ch_subsets_split = np.array_split(ch_subsets, n_splits)
+        delayed_func = delayed(self._get_mappings)
+        # no random seed needs to be supplied to get_mappings, as there is
+        # no random subsampling happening here
+        mappings = parallel(delayed_func(epochs, ch_subset) for ch_subset
+                                                          in ch_subsets_split)
+        self.mappings_ = np.concatenate(mappings)
+        
+        # compute correlations with possibility of parallelization
+        delayed_func = delayed(self._iterate_epochs)
+        n_splits = min(n_jobs, n_epochs) # max n_epochs splits possible
+        epoch_idxs_splits = np.array_split(np.arange(n_epochs), n_splits)
+        corrs = parallel(delayed_func(epochs, idxs) for idxs
+                         in epoch_idxs_splits)
         self.corr_ = np.concatenate(corrs)
-        if self.verbose is not False and self.n_jobs > 1:
+        
+        if self.verbose is not False:
             print('[Done]')
 
         # compute how many windows is a sensor RANSAC-bad

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -1,27 +1,28 @@
 # Author: Mainak Jas <mainak.jas@telecom-paristech.fr>
 # License: BSD-3-Clause
-
+import os
 import pytest
 
 import numpy as np
 import mne
 from mne.datasets import sample
 from mne import io
+import pickle
 
 from autoreject import Ransac
 
 import matplotlib
 matplotlib.use('Agg')
 
-data_path = sample.data_path()
-raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-raw = io.read_raw_fif(raw_fname, preload=False)
-raw.crop(0, 15)
-raw.del_proj()
-
 
 def test_ransac():
     """Some basic tests for ransac."""
+    data_path = sample.data_path()
+    raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
+    raw = io.read_raw_fif(raw_fname, preload=False)
+    raw.crop(0, 15)
+    raw.del_proj()
+
     event_id = {'Visual/Left': 3}
     tmin, tmax = -0.2, 0.5
 
@@ -61,8 +62,12 @@ def test_ransac():
     pytest.raises(ValueError, ransac.fit, epochs)
 
 
-        
 def test_ransac_multiprocessing():
+    """test on real data
+
+    test on real data with 5 random channels augmented with strong
+    50 Hz line noise.
+    """
     data_path = sample.data_path()
     raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
     raw = io.read_raw_fif(raw_fname, preload=False)
@@ -77,32 +82,31 @@ def test_ransac_multiprocessing():
                         baseline=(None, 0), reject=None, preload=True)
     # see if results are consistent when using different n_jobs
     # amplify some of the channels with noise as sanity check
-    np.random.seed(0)
-    
+    rng = np.random.RandomState(0)
+
     # create some artifically noisy channels with strong line noise
     mag_idx = mne.pick_types(epochs.info, meg='mag')
-    noisy_idx = np.random.choice(mag_idx, 5, replace=False)
+    noisy_idx = rng.choice(mag_idx, 5, replace=False)
     noisy_idx = sorted(noisy_idx)
-    
-    times = np.arange(0, epochs.tmax-epochs.tmin + 1/epochs.info['sfreq'], 
+
+    times = np.arange(0, epochs.tmax-epochs.tmin + 1/epochs.info['sfreq'],
                       1/epochs.info['sfreq'])
     sinewave = 10 * np.sin(2*np.pi*50*times)
-        
-    epochs._data[:,noisy_idx,:] *= sinewave
-   
-    
+
+    epochs._data[:, noisy_idx, :] *= sinewave
+
     # atomic tests for _get_mappings to check if they return the same
     # result when run "parallel" for subsets or all-in-once, sanity check
     ransac = Ransac(picks=mag_idx, random_state=np.random.RandomState(42),
-                        n_jobs=1, n_resample=2, min_channels=0.1)
+                    n_jobs=1, n_resample=2, min_channels=0.1)
     ch_subset = ransac._get_random_subsets(epochs.info)
-    ransac.ch_type='meg'
+    ransac.ch_type = 'meg'
     mappings = ransac._get_mappings(epochs, ch_subset)
     mappings_sub1 = ransac._get_mappings(epochs, [ch_subset[0]])
     mappings_sub2 = ransac._get_mappings(epochs, [ch_subset[1]])
-    
+
     np.testing.assert_array_equal(mappings, np.concatenate([mappings_sub1,
-                                                         mappings_sub2]))
+                                                            mappings_sub2]))
     # atomic tests for _iterate_epochs to check if they return the same
     # result when run "parallel" for subsets or all-in-once, sanity check
     ransac.mappings_ = mappings
@@ -114,35 +118,31 @@ def test_ransac_multiprocessing():
                                                         corr_sub2]))
 
     # now test across different jobs
-    mappings = {}
-    corrs = {}
-    bad_chs = {}
-    
-    for n_jobs in [1, 2, -1]:
-        
+    mappings = dict()
+    corrs = dict()
+    bad_chs = dict()
+
+    for n_jobs in [1, 2, 3]:
         ransac = Ransac(picks=mag_idx, random_state=np.random.RandomState(42),
                         n_jobs=n_jobs, n_resample=50)
         ransac.fit(epochs)
-        
+
         # the corr_ variable should be of shape (n_epochs, n_channels)
-        assert ransac.corr_.shape==(len(epochs), len(mag_idx))
+        assert ransac.corr_.shape == (len(epochs), len(mag_idx))
         corrs[n_jobs] = ransac.corr_
         bad_chs[n_jobs] = ransac.bad_chs_
         mappings[n_jobs] = ransac.mappings_
-        
+
         # should find all noisy bad channels
         bads = [epochs.ch_names.index(ch) for ch in ransac.bad_chs_]
         for noisy in noisy_idx:
             assert noisy in bads, \
                 f'bad channel {noisy} not detected, bads={bads}'
-        
+
     # test if results are consistent across different jobs
     for n_jobs in corrs:
+        msg = f'n_jobs={n_jobs} did not produce same results as n_jobs=1'
         # simply compare to the last computed value
-        np.testing.assert_allclose(mappings[1], mappings[n_jobs], err_msg=
-               f'n_jobs={n_jobs} did not produce same results as non-parallel')
-        np.testing.assert_allclose(corrs[1], corrs[n_jobs], err_msg=
-               f'n_jobs={n_jobs} did not produce same results as non-parallel')
-        assert bad_chs[1]==bad_chs[n_jobs], \
-               f'n_jobs={n_jobs} did not produce same results as non-parallel'
-
+        np.testing.assert_allclose(mappings[1], mappings[n_jobs], err_msg=msg)
+        np.testing.assert_allclose(corrs[1], corrs[n_jobs], err_msg=msg)
+        assert bad_chs[1] == bad_chs[n_jobs], msg

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -7,7 +7,6 @@ import numpy as np
 import mne
 from mne.datasets import sample
 from mne import io
-import pickle
 
 from autoreject import Ransac
 

--- a/autoreject/tests/test_ransac.py
+++ b/autoreject/tests/test_ransac.py
@@ -59,3 +59,90 @@ def test_ransac():
                            eog=False, exclude=[])
     ransac = Ransac(picks=picks)
     pytest.raises(ValueError, ransac.fit, epochs)
+
+
+        
+def test_ransac_multiprocessing():
+    data_path = sample.data_path()
+    raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
+    raw = io.read_raw_fif(raw_fname, preload=False)
+
+    raw.del_proj()
+
+    event_id = {'Visual/Left': 3}
+    tmin, tmax = -0.2, 0.5
+
+    events = mne.find_events(raw)
+    epochs = mne.Epochs(raw, events, event_id, tmin, tmax,
+                        baseline=(None, 0), reject=None, preload=True)
+    # see if results are consistent when using different n_jobs
+    # amplify some of the channels with noise as sanity check
+    np.random.seed(0)
+    
+    # create some artifically noisy channels with strong line noise
+    mag_idx = mne.pick_types(epochs.info, meg='mag')
+    noisy_idx = np.random.choice(mag_idx, 5, replace=False)
+    noisy_idx = sorted(noisy_idx)
+    
+    times = np.arange(0, epochs.tmax-epochs.tmin + 1/epochs.info['sfreq'], 
+                      1/epochs.info['sfreq'])
+    sinewave = 10 * np.sin(2*np.pi*50*times)
+        
+    epochs._data[:,noisy_idx,:] *= sinewave
+   
+    
+    # atomic tests for _get_mappings to check if they return the same
+    # result when run "parallel" for subsets or all-in-once, sanity check
+    ransac = Ransac(picks=mag_idx, random_state=np.random.RandomState(42),
+                        n_jobs=1, n_resample=2, min_channels=0.1)
+    ch_subset = ransac._get_random_subsets(epochs.info)
+    ransac.ch_type='meg'
+    mappings = ransac._get_mappings(epochs, ch_subset)
+    mappings_sub1 = ransac._get_mappings(epochs, [ch_subset[0]])
+    mappings_sub2 = ransac._get_mappings(epochs, [ch_subset[1]])
+    
+    np.testing.assert_array_equal(mappings, np.concatenate([mappings_sub1,
+                                                         mappings_sub2]))
+    # atomic tests for _iterate_epochs to check if they return the same
+    # result when run "parallel" for subsets or all-in-once, sanity check
+    ransac.mappings_ = mappings
+    epoch_idxs_splits = np.array_split(np.arange(len(epochs)), 2)
+    corr = ransac._iterate_epochs(epochs, np.arange(len(epochs)))
+    corr_sub1 = ransac._iterate_epochs(epochs, epoch_idxs_splits[0])
+    corr_sub2 = ransac._iterate_epochs(epochs, epoch_idxs_splits[1])
+    np.testing.assert_array_equal(corr, np.concatenate([corr_sub1,
+                                                        corr_sub2]))
+
+    # now test across different jobs
+    mappings = {}
+    corrs = {}
+    bad_chs = {}
+    
+    for n_jobs in [1, 2, -1]:
+        
+        ransac = Ransac(picks=mag_idx, random_state=np.random.RandomState(42),
+                        n_jobs=n_jobs, n_resample=50)
+        ransac.fit(epochs)
+        
+        # the corr_ variable should be of shape (n_epochs, n_channels)
+        assert ransac.corr_.shape==(len(epochs), len(mag_idx))
+        corrs[n_jobs] = ransac.corr_
+        bad_chs[n_jobs] = ransac.bad_chs_
+        mappings[n_jobs] = ransac.mappings_
+        
+        # should find all noisy bad channels
+        bads = [epochs.ch_names.index(ch) for ch in ransac.bad_chs_]
+        for noisy in noisy_idx:
+            assert noisy in bads, \
+                f'bad channel {noisy} not detected, bads={bads}'
+        
+    # test if results are consistent across different jobs
+    for n_jobs in corrs:
+        # simply compare to the last computed value
+        np.testing.assert_allclose(mappings[1], mappings[n_jobs], err_msg=
+               f'n_jobs={n_jobs} did not produce same results as non-parallel')
+        np.testing.assert_allclose(corrs[1], corrs[n_jobs], err_msg=
+               f'n_jobs={n_jobs} did not produce same results as non-parallel')
+        assert bad_chs[1]==bad_chs[n_jobs], \
+               f'n_jobs={n_jobs} did not produce same results as non-parallel'
+

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,8 @@ What's new?
 Changelog
 ~~~~~~~~~
 
+- RANSAC implementation was refactored, works now with `n_jobs>1` and produces consistent results across different number of jobs. Testing on simulated data added. by `Simon Kern`_ in :github:`#280`
+
 - ``autoreject`` now requires ``mne >= 1.0``, by `Mainak Jas`_, `Alex Gramfort`_, and `Stefan Appelhoff`_ in :github:`#267` and :github:`#268`
 
 - Add ``reject_log`` option to :meth:`autoreject.AutoReject.transform` to enable
@@ -100,3 +102,4 @@ Changelog
 .. _Patrick Stetz: https://patrickstetz.com
 .. _Stefan Appelhoff: https://stefanappelhoff.com/
 .. _Alex Rockhill: https://github.com/alexrockhill
+.. _Simon Kern: https://github.com/skjerns


### PR DESCRIPTION
closes #277 
closes #278 

The current implementation of RANSAC has some bugs renderering it faulty&non-functioning for `n_jobs>1`, and I'm not even sure if the case `n_jobs=1` is maybe also affected by this in certain cases.

I introduce and propose the following changes:
* Compute the mappings (interpolations of subsets of channels) with `Parallel`,  `_get_mappings` is actually the slow part of RANSAC and benefits of parallelization the most (at least for MEG data).
* Fix two bugs (list index taken instead of actual channel index, iterating over spaces of n_jobs instead of all epochs) see also #277 and #278 for details, additionally, the corresponding lines have been commented on in the review )
* The only part that needs randomization is `_get_random_subsets`, which does not need to be parallel, so we can just compute it outside of a Parallel context and don't have to worry about random seeds in subprocesses.
* Bad channels should be excluded from the random subset selection processes. This is excluded later anyway by the interpolation function, but it would probably be good to already exclude them during the random sampling process. Else we possibly have a bias if one random subset contains too many bad channels.
* Additionally I added some sanity checks,. warnings and a test with actual data (artificial line noise added)
 
I propose refactoring these changes
* move `_get_channel_type` to utils
* Be more consistent with `verbose`
* move all functions inside the RANSAC class, `Parallel` has no problem with class methods