### PR TITLE
MAINT: Bump in prep for release

### DIFF
--- a/autoreject/__init__.py
+++ b/autoreject/__init__.py
@@ -1,5 +1,5 @@
 """Automated rejection and repair of epochs in M/EEG."""
-__version__ = '0.4.dev0'
+__version__ = '0.4.0'
 
 from .autoreject import _GlobalAutoReject, _AutoReject, AutoReject
 from .autoreject import RejectLog, read_auto_reject, read_reject_log

--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -9,6 +9,7 @@
   <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
     <li><a href="https://autoreject.github.io/dev/index.html">Development</a></li>
     <li><a href="https://autoreject.github.io/stable/index.html">Stable</a></li>
+    <li><a href="https://autoreject.github.io/v0.4/index.html">v0.4</a></li>
     <li><a href="https://autoreject.github.io/v0.3/index.html">v0.3</a></li>
     <li><a href="https://autoreject.github.io/v0.2/index.html">v0.2</a></li>
   </ul>

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -9,7 +9,7 @@ What's new?
 
 .. _0.4:
 
-0.4 (unreleased)
+0.4 (2022-10-09)
 ----------------
 
 Changelog


### PR DESCRIPTION
Bumping minor version from 0.3 to 0.4.

I considered a patch bump from 0.3.2 to 0.3.3 but it seemed like there was enough stuff (like ECoG/sEEG support) to justify a new minor bump.

Closes #288