### PR TITLE
Sort Autoreject.picks to avoid AssertionError

### DIFF
--- a/autoreject/autoreject.py
+++ b/autoreject/autoreject.py
@@ -1001,6 +1001,7 @@ class AutoReject:
             The instance.
         """
         self.picks_ = _handle_picks(info=epochs.info, picks=self.picks)
+        self.picks_.sort()
         _check_data(epochs, picks=self.picks_, verbose=self.verbose)
         self.cv_ = self.cv
         if isinstance(self.cv_, int):

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -160,6 +160,12 @@ def test_autoreject():
 
     ar = _AutoReject(picks=picks)  # XXX : why do we need this??
 
+    # Confirm that flipping the channel order does not yield errors
+    flipped_picks = pick_ch_names[::-1]
+    ar = AutoReject(cv=3, picks=flipped_picks, random_state=42,
+                    n_interpolate=[1, 2], consensus=[0.5, 1])
+    pytest.raises(AssertionError, ar.fit, epochs)
+
     ar = AutoReject(cv=3, picks=picks, random_state=42,
                     n_interpolate=[1, 2], consensus=[0.5, 1])
     pytest.raises(AttributeError, ar.fit, X)

--- a/autoreject/tests/test_autoreject.py
+++ b/autoreject/tests/test_autoreject.py
@@ -161,10 +161,10 @@ def test_autoreject():
     ar = _AutoReject(picks=picks)  # XXX : why do we need this??
 
     # Confirm that flipping the channel order does not yield errors
-    flipped_picks = pick_ch_names[::-1]
+    flipped_picks = picks[::-1]
     ar = AutoReject(cv=3, picks=flipped_picks, random_state=42,
                     n_interpolate=[1, 2], consensus=[0.5, 1])
-    pytest.raises(AssertionError, ar.fit, epochs)
+    ar.fit(epochs)
 
     ar = AutoReject(cv=3, picks=picks, random_state=42,
                     n_interpolate=[1, 2], consensus=[0.5, 1])

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,6 +17,11 @@ Changelog
 
 - Nothing yet
 
+Bug
+~~~
+
+- Fix related to specifying `picks` with unsorted lists by `Paul Bogdan`_ in :github:`#312`
+
 .. _0.4.2:
 
 0.4.2 (2023-05-28)
@@ -153,3 +158,4 @@ Changelog
 .. _Nikolai Chapochnikov: https://github.com/chapochn
 .. _Simon Kern: https://github.com/skjerns
 .. _Eric Larson: https://larsoner.com
+.. _Paul Bogdan: http://pbogdan.com/

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,7 +20,7 @@ Changelog
 Bug
 ~~~
 
-- Fix related to specifying `picks` with unsorted lists by `Paul Bogdan`_ in :github:`#312`
+- Fixed bug that arose if `picks` was specified with an unsorted list, by `Paul Bogdan`_ in :github:`#312`
 
 .. _0.4.2:
 


### PR DESCRIPTION
I describe the issue being fixed here: https://github.com/autoreject/autoreject/issues/309#issuecomment-1689276690