### PR TITLE
Fix kernel parameters

### DIFF
--- a/autoreject/bayesopt.py
+++ b/autoreject/bayesopt.py
@@ -48,7 +48,9 @@ def bayes_opt(f, initial_x, all_x, acquisition, max_iter=100, debug=False,
 
     best_x = X[np.argmin(y)]
     best_f = y[np.argmin(y)]
-    gp = gaussian_process.GaussianProcessRegressor(random_state=random_state)
+    gp = gaussian_process.GaussianProcessRegressor(
+        random_state=random_state, optimizer=None
+    )
 
     if debug:  # pragma: no cover
         print("iter", -1, "best_x", best_x, best_f)


### PR DESCRIPTION
Should fix behavior with newer sklearn, and be backward compatible with older versions. Setting `optimizer=None` explicitly fixes the parameters... if they aren't fixed, behavior changes quite a bit (go from 3 epochs rejected to 80 out of 400 for subject 16 of ERP_CORE_ERN in MNE-BIDS-Pipeline).

Notably this should restore old behavior, for me it did locally at least, and I'm testing it remotely in https://github.com/mne-tools/mne-bids-pipeline/pull/1253 . While it's possible the newer 1.9.0 behavior is better in some way, that will require some investigation.

In the meantime I think we should merge this and cut a 0.4.4 immediately.